### PR TITLE
[WEAV-20] ✨ 소셜 로그인 API 모의 응답 구현

### DIFF
--- a/bootstrap/http/build.gradle.kts
+++ b/bootstrap/http/build.gradle.kts
@@ -1,7 +1,13 @@
 dependencies {
+    implementation(project(":support:common"))
+    implementation(project(":domain"))
     implementation(project(":application"))
     implementation(project(":infrastructure:client"))
     implementation(project(":infrastructure:persistence"))
 
     implementation("org.springframework.boot:spring-boot-starter-web:${Version.SPRING_BOOT}")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${Version.SPRINGDOC_OPENAPI}")
+
+    developmentOnly("org.springframework.boot:spring-boot-devtools:${Version.SPRING_BOOT}")
+    developmentOnly("org.springframework.boot:spring-boot-docker-compose:${Version.SPRING_BOOT}")
 }

--- a/bootstrap/http/compose-dev.yaml
+++ b/bootstrap/http/compose-dev.yaml
@@ -7,5 +7,3 @@ services:
       - "MYSQL_ROOT_PASSWORD=secret"
     ports:
       - "3306:3306"
-    volumes:
-      - ./db/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql

--- a/bootstrap/http/compose-dev.yaml
+++ b/bootstrap/http/compose-dev.yaml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  mysql:
+    image: mysql:8.0.33
+    environment:
+      - "MYSQL_DATABASE=user"
+      - "MYSQL_ROOT_PASSWORD=secret"
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./db/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/AuthApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/AuthApi.kt
@@ -1,0 +1,30 @@
+package com.studentcenter.weave.bootstrap.adapter.api
+
+import com.studentcenter.weave.bootstrap.adapter.dto.RefreshLoginTokenResponse
+import com.studentcenter.weave.bootstrap.adapter.dto.SocialLoginResponse
+import com.studentcenter.weave.domain.enum.SocialLoginProvider
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "인증", description = "회원 인증 API")
+@RequestMapping("/api/auth", produces = ["application/json;charset=utf-8"])
+interface AuthApi {
+
+    @Operation(summary = "소셜 로그인 API - 로그인 토큰 발급")
+    @GetMapping("/login/oauth2/code/{provider}")
+    @ResponseStatus(HttpStatus.OK)
+    fun socialLogin(
+        @PathVariable provider: SocialLoginProvider,
+        @RequestParam code: String
+    ): SocialLoginResponse
+
+    @Operation(summary = "로그인 토큰 갱신 API")
+    @GetMapping("/login/refresh")
+    @ResponseStatus(HttpStatus.OK)
+    fun refreshLoginToken(
+        @RequestParam refreshToken: String
+    ): RefreshLoginTokenResponse
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/AuthRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/AuthRestController.kt
@@ -13,15 +13,15 @@ class AuthRestController: AuthApi {
         code: String,
     ): SocialLoginResponse {
         return SocialLoginResponse.Success(
-            accessToken =  "test_token",
-            refreshToken = "test_token",
+            accessToken =  "test_access_token",
+            refreshToken = "test_refresh_token",
         )
     }
 
     override fun refreshLoginToken(refreshToken: String): RefreshLoginTokenResponse {
         return RefreshLoginTokenResponse(
-            accessToken =  "test_token",
-            refreshToken = "test_token",
+            accessToken =  "test_access_token",
+            refreshToken = "test_refresh_token",
         )
     }
 

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/AuthRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/AuthRestController.kt
@@ -1,0 +1,28 @@
+package com.studentcenter.weave.bootstrap.adapter.controller
+
+import com.studentcenter.weave.bootstrap.adapter.api.AuthApi
+import com.studentcenter.weave.bootstrap.adapter.dto.RefreshLoginTokenResponse
+import com.studentcenter.weave.bootstrap.adapter.dto.SocialLoginResponse
+import com.studentcenter.weave.domain.enum.SocialLoginProvider
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AuthRestController: AuthApi {
+    override fun socialLogin(
+        provider: SocialLoginProvider,
+        code: String,
+    ): SocialLoginResponse {
+        return SocialLoginResponse.Success(
+            accessToken =  "test_token",
+            refreshToken = "test_token",
+        )
+    }
+
+    override fun refreshLoginToken(refreshToken: String): RefreshLoginTokenResponse {
+        return RefreshLoginTokenResponse(
+            accessToken =  "test_token",
+            refreshToken = "test_token",
+        )
+    }
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/RefreshLoginTokenResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/RefreshLoginTokenResponse.kt
@@ -1,0 +1,12 @@
+package com.studentcenter.weave.bootstrap.adapter.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+    name = "로그인 토큰 갱신 응답",
+    description = "로그인 토큰 갱신 요청시 access token, refresh token 을 반환합니다"
+)
+data class RefreshLoginTokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/SocialLoginResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/SocialLoginResponse.kt
@@ -2,7 +2,6 @@ package com.studentcenter.weave.bootstrap.adapter.dto
 
 import com.studentcenter.weave.domain.enum.SocialLoginProvider
 import com.studentcenter.weave.support.common.vo.Email
-import com.studentcenter.weave.support.common.vo.Url
 import io.swagger.v3.oas.annotations.media.Schema
 
 
@@ -32,7 +31,6 @@ sealed class SocialLoginResponse {
         val name: String,
         val email: Email,
         val provider: SocialLoginProvider,
-        val picture: Url?,
     ) : SocialLoginResponse()
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/SocialLoginResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/SocialLoginResponse.kt
@@ -1,0 +1,38 @@
+package com.studentcenter.weave.bootstrap.adapter.dto
+
+import com.studentcenter.weave.domain.enum.SocialLoginProvider
+import com.studentcenter.weave.support.common.vo.Email
+import com.studentcenter.weave.support.common.vo.Url
+import io.swagger.v3.oas.annotations.media.Schema
+
+
+@Schema(
+    name = "소셜 로그인 응답",
+    oneOf = [
+        SocialLoginResponse.Success::class,
+        SocialLoginResponse.UserNotRegistered::class,
+    ],
+)
+sealed class SocialLoginResponse {
+
+    @Schema(
+        name = "소셜 로그인 성공 응답",
+        description = "소셜 로그인 성공시 access token, refresh token 을 반환합니다",
+    )
+    data class Success(
+        val accessToken: String,
+        val refreshToken: String,
+    ) : SocialLoginResponse()
+
+    @Schema(
+        name = "소셜 로그인 실패 응답 - 회원 가입 필요",
+        description = "회원 가입이 필요한 경우, 회원가입을 위한 사용자 정보를 반환합니다",
+    )
+    data class UserNotRegistered(
+        val name: String,
+        val email: Email,
+        val provider: SocialLoginProvider,
+        val picture: Url?,
+    ) : SocialLoginResponse()
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/SocialLoginResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/SocialLoginResponse.kt
@@ -1,7 +1,5 @@
 package com.studentcenter.weave.bootstrap.adapter.dto
 
-import com.studentcenter.weave.domain.enum.SocialLoginProvider
-import com.studentcenter.weave.support.common.vo.Email
 import io.swagger.v3.oas.annotations.media.Schema
 
 
@@ -25,12 +23,13 @@ sealed class SocialLoginResponse {
 
     @Schema(
         name = "소셜 로그인 실패 응답 - 회원 가입 필요",
-        description = "회원 가입이 필요한 경우, 회원가입을 위한 사용자 정보를 반환합니다",
+        description = """
+            회원 가입이 필요한 경우, 회원가입을 위한 사용자 정보가 담긴 register token을 반환합니다.
+            추후 회원가입 API 호출시 해당 토큰을 header에 담아 전송해야 합니다.
+        """,
     )
     data class UserNotRegistered(
-        val name: String,
-        val email: Email,
-        val provider: SocialLoginProvider,
+        val registerToken: String,
     ) : SocialLoginResponse()
 
 }

--- a/bootstrap/http/src/main/resources/application.yaml
+++ b/bootstrap/http/src/main/resources/application.yaml
@@ -1,0 +1,44 @@
+server:
+  port: 8080
+  shutdown: graceful
+spring:
+  profiles:
+    active: local
+    include:
+      - client
+      - application
+      - persistence
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  docker:
+    compose:
+      file: ./bootstrap/http/compose-dev.yaml
+springdoc:
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+  docker:
+    compose:
+      file: ./bootstrap/http/compose-dev.yaml
+springdoc:
+  swagger-ui:
+    enabled: true
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  docker:
+    compose:
+      enabled: false
+springdoc:
+  swagger-ui:
+    enabled: false

--- a/buildSrc/src/main/kotlin/Version.kt
+++ b/buildSrc/src/main/kotlin/Version.kt
@@ -16,4 +16,5 @@ object Version {
     const val KOTEST_EXTENSIONS_SPRING = "1.1.3"
 
     const val JACKSON = "2.16.1"
+    const val SPRINGDOC_OPENAPI = "2.3.0"
 }

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/enum/SocialLoginProvider.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/enum/SocialLoginProvider.kt
@@ -1,0 +1,6 @@
+package com.studentcenter.weave.domain.enum
+
+enum class SocialLoginProvider {
+    KAKAO,
+    APPLE
+}

--- a/support/common/src/main/kotlin/com/studentcenter/weave/support/common/vo/Email.kt
+++ b/support/common/src/main/kotlin/com/studentcenter/weave/support/common/vo/Email.kt
@@ -8,11 +8,11 @@ package com.studentcenter.weave.support.common.vo
 value class Email(val value: String) {
 
     companion object {
-        const val VALIDATION_REGEX = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+        const val VALIDATION_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}\$"
         const val VALIDATION_MESSAGE = "잘못된 Email 형식 입니다."
     }
 
     init {
-        require(value.matches(Regex(VALIDATION_REGEX))) { VALIDATION_MESSAGE }
+        require(value.matches(VALIDATION_REGEX.toRegex())) { VALIDATION_MESSAGE }
     }
 }

--- a/support/common/src/main/kotlin/com/studentcenter/weave/support/common/vo/Email.kt
+++ b/support/common/src/main/kotlin/com/studentcenter/weave/support/common/vo/Email.kt
@@ -1,0 +1,18 @@
+package com.studentcenter.weave.support.common.vo
+
+/**
+ * @param value 이메일 주소 문자열
+ * @throws IllegalArgumentException 이메일 주소가 올바른 형식이 아닌 경우
+ */
+@JvmInline
+value class Email(val value: String) {
+
+    companion object {
+        const val VALIDATION_REGEX = "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+        const val VALIDATION_MESSAGE = "잘못된 Email 형식 입니다."
+    }
+
+    init {
+        require(value.matches(Regex(VALIDATION_REGEX))) { VALIDATION_MESSAGE }
+    }
+}

--- a/support/common/src/main/kotlin/com/studentcenter/weave/support/common/vo/Url.kt
+++ b/support/common/src/main/kotlin/com/studentcenter/weave/support/common/vo/Url.kt
@@ -13,6 +13,6 @@ value class Url(val value: String) {
     }
 
     init {
-        require(value.matches(Regex(VALIDATION_REGEX))) { VALIDATION_MESSAGE }
+        require(value.matches(VALIDATION_REGEX.toRegex())) { VALIDATION_MESSAGE }
     }
 }

--- a/support/common/src/main/kotlin/com/studentcenter/weave/support/common/vo/Url.kt
+++ b/support/common/src/main/kotlin/com/studentcenter/weave/support/common/vo/Url.kt
@@ -1,0 +1,18 @@
+package com.studentcenter.weave.support.common.vo
+
+/**
+ * @property value URL 형식 문자열
+ * @throws IllegalArgumentException URL 형식이 아닌 경우
+ */
+@JvmInline
+value class Url(val value: String) {
+
+    companion object {
+        const val VALIDATION_REGEX = "^(http|https)://.*"
+        const val VALIDATION_MESSAGE = "잘못된 URL 형식입니다."
+    }
+
+    init {
+        require(value.matches(Regex(VALIDATION_REGEX))) { VALIDATION_MESSAGE }
+    }
+}

--- a/support/common/src/test/kotlin/com/studentcenter/weave/support/common/vo/EmailTest.kt
+++ b/support/common/src/test/kotlin/com/studentcenter/weave/support/common/vo/EmailTest.kt
@@ -1,0 +1,19 @@
+package com.studentcenter.weave.support.common.vo
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+
+class EmailTest: FunSpec({
+
+    test("이메일 주소가 올바른 형식이 아닌 경우 예외가 발생한다.") {
+        val invalidEmail = "invalid_email"
+        shouldThrow<IllegalArgumentException> {
+            Email(invalidEmail)
+        }
+    }
+
+    test("이메일 주소가 올바른 형식인 경우 객체가 생성된다.") {
+        val validEmail = "test1234@test.com"
+        Email(validEmail)
+    }
+})

--- a/support/common/src/test/kotlin/com/studentcenter/weave/support/common/vo/UrlTest.kt
+++ b/support/common/src/test/kotlin/com/studentcenter/weave/support/common/vo/UrlTest.kt
@@ -1,0 +1,20 @@
+package com.studentcenter.weave.support.common.vo
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+
+class UrlTest : FunSpec({
+
+    test("URL 형식이 아닌 경우 예외가 발생한다.") {
+        val invalidUrl = "invalid_url"
+        shouldThrow<IllegalArgumentException> {
+            Url(invalidUrl)
+        }
+    }
+
+    test("URL 형식인 경우 객체가 생성된다.") {
+        val validUrl = "https://test.com"
+        Url(validUrl)
+    }
+
+})


### PR DESCRIPTION
## 구현사항

- 소셜 로그인 API with 모의응답
  - 소셜 로그인시 회원가입 되어있을 경우 -> 로그인 토큰 응답(access token, refresh token) 
  - 소셜 로그인시 회원가입이 되어있지 않을 경우 -> 클라이언트에게 회원가입에 필요한 정보 토큰으로 제공(이메일, 닉네임, 소셜로그인 제공자)
- 로그인 토큰 갱신 API with 모의 응답