### PR TITLE
[WEAV-21] ✨ 개발서버 CI workflow 구현

### DIFF
--- a/.github/workflows/ci_dev.yaml
+++ b/.github/workflows/ci_dev.yaml
@@ -1,0 +1,39 @@
+name: CI - Dev
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repository
+        uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Build, tag, and push docker image to Amazon ECR Public
+        env:
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: h3l4i6v1
+          REPOSITORY: weave_server_dev_cr
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -f Dockerfile-http -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
+
+      - name: Logout of Amazon ECR
+        run: docker logout ${{ env.ECR_REGISTRY }}

--- a/Dockerfile-http
+++ b/Dockerfile-http
@@ -1,0 +1,11 @@
+# Build stage
+FROM gradle:jdk17 AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle :bootstrap:http:bootJar --no-daemon
+
+# Package stage
+FROM openjdk:17
+COPY --from=build /home/gradle/src/bootstrap/http/build/libs/http-*.jar /app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/bootstrap/http/compose-dev.yaml
+++ b/bootstrap/http/compose-dev.yaml
@@ -1,9 +1,18 @@
 version: '3.8'
 services:
+  spring:
+    image: public.ecr.aws/h3l4i6v1/weave_server_dev_cr
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      DB_URL: jdbc:mysql://mysql/weave?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&allowPublicKeyRetrieval=true
+      DB_USERNAME: root
+      DB_PASSWORD: secret
+    depends_on:
+      - mysql
   mysql:
     image: mysql:8.0.33
     environment:
-      - "MYSQL_DATABASE=user"
-      - "MYSQL_ROOT_PASSWORD=secret"
+      MYSQL_DATABASE: weave
+      MYSQL_ROOT_PASSWORD: secret
     ports:
       - "3306:3306"

--- a/bootstrap/http/compose-local.yaml
+++ b/bootstrap/http/compose-local.yaml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  mysql:
+    image: mysql:8.0.33
+    environment:
+      MYSQL_DATABASE: weave
+      MYSQL_ROOT_PASSWORD: secret
+    ports:
+      - "3306:3306"

--- a/bootstrap/http/src/main/resources/application.yaml
+++ b/bootstrap/http/src/main/resources/application.yaml
@@ -15,7 +15,7 @@ spring:
       on-profile: local
   docker:
     compose:
-      file: ./bootstrap/http/compose-dev.yaml
+      file: ./bootstrap/http/compose-local.yaml
 springdoc:
   swagger-ui:
     enabled: true
@@ -27,7 +27,7 @@ spring:
       on-profile: dev
   docker:
     compose:
-      file: ./bootstrap/http/compose-dev.yaml
+      enabled: false
 springdoc:
   swagger-ui:
     enabled: true

--- a/buildSrc/src/main/kotlin/Version.kt
+++ b/buildSrc/src/main/kotlin/Version.kt
@@ -17,4 +17,7 @@ object Version {
 
     const val JACKSON = "2.16.1"
     const val SPRINGDOC_OPENAPI = "2.3.0"
+
+    const val MYSQL = "8.0.33"
+    const val H2 = "2.2.224"
 }

--- a/infrastructure/persistence/build.gradle.kts
+++ b/infrastructure/persistence/build.gradle.kts
@@ -9,4 +9,8 @@ jar.enabled = true
 dependencies {
     implementation(project(":domain"))
     implementation(project(":application"))
+
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:${Version.SPRING_BOOT}")
+    runtimeOnly("mysql:mysql-connector-java:${Version.MYSQL}")
+    testRuntimeOnly("com.h2database:h2:${Version.H2}")
 }

--- a/infrastructure/persistence/src/main/resources/application-persistence.yaml
+++ b/infrastructure/persistence/src/main/resources/application-persistence.yaml
@@ -1,0 +1,32 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL:jdbc:mysql://localhost:3306/weave?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:secret}
+  jpa:
+    open-in-view: false
+    hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    properties:
+      hibernate.format_sql: true
+      dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true


### PR DESCRIPTION
CI 작업하다보니 계속 길어져서 일단 여기서 끊고 완료되면 CD랑 인프라 작업 진행하려구요

## 구현사항
- 영속성 관련 설정(지금 안해두면 나중에 CI 설정 에 또 반영해야해서 미리 설정해두었어요)
- local, dev는 설정 노출되어있긴 한데, 프로덕션이 아니라 크게 문제없을것 같아요

## 진행방향

### 개발 서버 CI 프로세스

1. main브렌치에 push
2. aws의 public container registry에 도커이미지 빌드, push
3. compose-dev.yaml : 깃레포에서 인스턴스로 복사
4. 인스턴스에서 `docker compose up -d` 명령어 수행

```yaml
services:
  spring:
    image: public.ecr.aws/h3l4i6v1/weave_server_dev_cr
    ...
```

### 도커 레지스트리

docker container registry의 경우에는 dev, prod 레지스트리 나눌려고 해요

- main push -> image build -> dev registry -> 개발 ec2 instance (docker compose up)
- release push -> image build -> prod registry -> 배포 ec2 instance (elastic beanstalk or ec2 + AWS RDS + ...)

