### PR TITLE
[WEAV-49] 로그인 기능 애플리케이션 레이어 구현

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -7,5 +7,9 @@ bootJar.enabled = false
 jar.enabled = true
 
 dependencies {
+    implementation(project(":support:common"))
     implementation(project(":domain"))
+
+    implementation("org.springframework.boot:spring-boot:${Version.SPRING_BOOT}")
+    testImplementation(testFixtures(project(":domain")))
 }

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot:${Version.SPRING_BOOT}")
     testImplementation(testFixtures(project(":domain")))
+    testFixturesImplementation(testFixtures(project(":domain")))
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/common/config/ApplicationConfig.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/common/config/ApplicationConfig.kt
@@ -1,0 +1,13 @@
+package com.studentcenter.weave.application.common.config
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+@ComponentScan(basePackages = ["com.studentcenter.weave.application"])
+@EnableConfigurationProperties
+@ConfigurationPropertiesScan(basePackages = ["com.studentcenter.weave.application"])
+class ApplicationConfig

--- a/application/src/main/kotlin/com/studentcenter/weave/application/port/inbound/UserSocialLoginUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/port/inbound/UserSocialLoginUseCase.kt
@@ -1,0 +1,27 @@
+package com.studentcenter.weave.application.port.inbound
+
+import com.studentcenter.weave.domain.enum.SocialLoginProvider
+
+fun interface UserSocialLoginUseCase {
+
+    fun invoke(command: Command): Result
+
+    data class Command(
+        val socialLoginProvider: SocialLoginProvider,
+        val idToken: String,
+    )
+
+    sealed class Result {
+
+        data class Success(
+            val accessToken: String,
+            val refreshToken: String,
+        ) : Result()
+
+        data class NotRegistered(
+            val registerToken: String,
+        ) : Result()
+
+    }
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/service/UserTokenService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/service/UserTokenService.kt
@@ -1,0 +1,40 @@
+package com.studentcenter.weave.application.service
+
+import com.studentcenter.weave.application.vo.UserTokenClaims
+import com.studentcenter.weave.domain.entity.User
+import com.studentcenter.weave.domain.enum.SocialLoginProvider
+import com.studentcenter.weave.support.common.vo.Email
+
+interface UserTokenService {
+
+    fun resolveIdToken(
+        idToken: String,
+        provider: SocialLoginProvider,
+    ): UserTokenClaims.IdToken
+
+    fun generateRegisterToken(
+        email: Email,
+        provider: SocialLoginProvider,
+    ): String
+
+    fun resolveRegisterToken(
+        registerToken: String,
+    ): UserTokenClaims.RegisterToken
+
+    fun generateAccessToken(
+        user: User,
+    ): String
+
+    fun resolveAccessToken(
+        accessToken: String,
+    ): UserTokenClaims.AccessToken
+
+    fun generateRefreshToken(
+        user: User,
+    ): String
+
+    fun resolveRefreshToken(
+        refreshToken: String,
+    ): UserTokenClaims.RefreshToken
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationService.kt
@@ -22,20 +22,13 @@ class UserSocialLoginApplicationService(
             provider = command.socialLoginProvider,
         )
 
-        val userAuthInfo: UserAuthInfo? =
-            userAuthInfoDomainService.findByEmailAndSocialLoginProvider(
-                email = idTokenClaims.email,
-                socialLoginProvider = command.socialLoginProvider,
-            )
-
-        if (userAuthInfo == null) {
-            return UserSocialLoginUseCase.Result.NotRegistered(
+        val userAuthInfo: UserAuthInfo = userAuthInfoDomainService.findByEmail(email = idTokenClaims.email)
+            ?: return UserSocialLoginUseCase.Result.NotRegistered(
                 registerToken = userTokenService.generateRegisterToken(
                     email = idTokenClaims.email,
                     provider = command.socialLoginProvider,
                 ),
             )
-        }
 
         val user: User = userDomainService.getById(userAuthInfo.userId)
         return UserSocialLoginUseCase.Result.Success(

--- a/application/src/main/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationService.kt
@@ -1,0 +1,47 @@
+package com.studentcenter.weave.application.service.application
+
+import com.studentcenter.weave.application.port.inbound.UserSocialLoginUseCase
+import com.studentcenter.weave.application.service.UserTokenService
+import com.studentcenter.weave.application.service.domain.UserAuthInfoDomainService
+import com.studentcenter.weave.application.service.domain.UserDomainService
+import com.studentcenter.weave.application.vo.UserTokenClaims
+import com.studentcenter.weave.domain.entity.User
+import com.studentcenter.weave.domain.entity.UserAuthInfo
+import org.springframework.stereotype.Service
+
+@Service
+class UserSocialLoginApplicationService(
+    private val userTokenService: UserTokenService,
+    private val userDomainService: UserDomainService,
+    private val userAuthInfoDomainService: UserAuthInfoDomainService,
+) : UserSocialLoginUseCase {
+
+    override fun invoke(command: UserSocialLoginUseCase.Command): UserSocialLoginUseCase.Result {
+        val idTokenClaims: UserTokenClaims.IdToken = userTokenService.resolveIdToken(
+            idToken = command.idToken,
+            provider = command.socialLoginProvider,
+        )
+
+        val userAuthInfo: UserAuthInfo? =
+            userAuthInfoDomainService.findByEmailAndSocialLoginProvider(
+                email = idTokenClaims.email,
+                socialLoginProvider = command.socialLoginProvider,
+            )
+
+        if (userAuthInfo == null) {
+            return UserSocialLoginUseCase.Result.NotRegistered(
+                registerToken = userTokenService.generateRegisterToken(
+                    email = idTokenClaims.email,
+                    provider = command.socialLoginProvider,
+                ),
+            )
+        }
+
+        val user: User = userDomainService.getById(userAuthInfo.userId)
+        return UserSocialLoginUseCase.Result.Success(
+            accessToken = userTokenService.generateAccessToken(user),
+            refreshToken = userTokenService.generateRefreshToken(user)
+        )
+    }
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationService.kt
@@ -22,7 +22,7 @@ class UserSocialLoginApplicationService(
             provider = command.socialLoginProvider,
         )
 
-        val userAuthInfo: UserAuthInfo = userAuthInfoDomainService.findByEmail(email = idTokenClaims.email)
+        val userAuthInfo: UserAuthInfo = userAuthInfoDomainService.findByEmail(idTokenClaims.email)
             ?: return UserSocialLoginUseCase.Result.NotRegistered(
                 registerToken = userTokenService.generateRegisterToken(
                     email = idTokenClaims.email,

--- a/application/src/main/kotlin/com/studentcenter/weave/application/service/domain/UserAuthInfoDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/service/domain/UserAuthInfoDomainService.kt
@@ -1,0 +1,14 @@
+package com.studentcenter.weave.application.service.domain
+
+import com.studentcenter.weave.domain.entity.UserAuthInfo
+import com.studentcenter.weave.domain.enum.SocialLoginProvider
+import com.studentcenter.weave.support.common.vo.Email
+
+interface UserAuthInfoDomainService {
+
+    fun findByEmailAndSocialLoginProvider(
+        email: Email,
+        socialLoginProvider: SocialLoginProvider,
+    ): UserAuthInfo?
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/service/domain/UserAuthInfoDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/service/domain/UserAuthInfoDomainService.kt
@@ -1,14 +1,10 @@
 package com.studentcenter.weave.application.service.domain
 
 import com.studentcenter.weave.domain.entity.UserAuthInfo
-import com.studentcenter.weave.domain.enum.SocialLoginProvider
 import com.studentcenter.weave.support.common.vo.Email
 
 interface UserAuthInfoDomainService {
 
-    fun findByEmailAndSocialLoginProvider(
-        email: Email,
-        socialLoginProvider: SocialLoginProvider,
-    ): UserAuthInfo?
+    fun findByEmail(email: Email): UserAuthInfo?
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/service/domain/UserDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/service/domain/UserDomainService.kt
@@ -1,0 +1,10 @@
+package com.studentcenter.weave.application.service.domain
+
+import com.studentcenter.weave.domain.entity.User
+import java.util.UUID
+
+
+interface UserDomainService {
+
+    fun getById(id: UUID): User
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/service/domain/UserDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/service/domain/UserDomainService.kt
@@ -7,4 +7,5 @@ import java.util.UUID
 interface UserDomainService {
 
     fun getById(id: UUID): User
+
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/vo/UserTokenClaims.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/vo/UserTokenClaims.kt
@@ -1,0 +1,33 @@
+package com.studentcenter.weave.application.vo
+
+import com.studentcenter.weave.domain.enum.SocialLoginProvider
+import com.studentcenter.weave.domain.vo.Nickname
+import com.studentcenter.weave.support.common.vo.Email
+import com.studentcenter.weave.support.common.vo.Url
+import java.util.*
+
+sealed class UserTokenClaims {
+
+    data class IdToken(
+        val nickname: Nickname,
+        val email: Email,
+    ) : UserTokenClaims()
+
+    data class AccessToken(
+        val userId: UUID,
+        val nickname: Nickname,
+        val email: Email,
+        val avatar: Url?,
+    ) : UserTokenClaims()
+
+    data class RegisterToken(
+        val nickname: Nickname,
+        val email: Email,
+        val socialLoginProvider: SocialLoginProvider,
+    ) : UserTokenClaims()
+
+    data class RefreshToken(
+        val userId: UUID,
+    ) : UserTokenClaims()
+
+}

--- a/application/src/test/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationServiceTest.kt
@@ -28,59 +28,54 @@ class UserSocialLoginApplicationServiceTest : DescribeSpec({
         context("소셜 로그인 성공시") {
 
             every {
-                authInfoDomainServiceMock.findByEmailAndSocialLoginProvider(
-                    userAuthInfoFixture.email,
-                    userAuthInfoFixture.socialLoginProvider
-                )
+                authInfoDomainServiceMock.findByEmail(userAuthInfoFixture.email)
             } returns UserAuthInfoFixtureFactory.create()
 
-            it("Access Token과 Refresh Token을 응답한다") {
-                // arrange
-                val socialLoginProvider = SocialLoginProvider.KAKAO
-                val idToken = "idToken"
-                val command = UserSocialLoginUseCase.Command(
-                    socialLoginProvider = socialLoginProvider,
-                    idToken = idToken,
-                )
+            enumValues<SocialLoginProvider>().forEach { socialLoginProvider ->
 
-                // act
-                val result: UserSocialLoginUseCase.Result = sut.invoke(command)
+                it("Access Token과 Refresh Token을 응답한다 : ${socialLoginProvider.name}") {
+                    // arrange
+                    val idToken = "idToken"
+                    val command = UserSocialLoginUseCase.Command(
+                        socialLoginProvider = socialLoginProvider,
+                        idToken = idToken,
+                    )
 
-                // assert
-                result.shouldBeTypeOf<UserSocialLoginUseCase.Result.Success>()
-                result.accessToken.shouldBeTypeOf<String>()
-                result.refreshToken.shouldBeTypeOf<String>()
+                    // act
+                    val result: UserSocialLoginUseCase.Result = sut.invoke(command)
+
+                    // assert
+                    result.shouldBeTypeOf<UserSocialLoginUseCase.Result.Success>()
+                    result.accessToken.shouldBeTypeOf<String>()
+                    result.refreshToken.shouldBeTypeOf<String>()
+                }
             }
         }
 
         context("회원이 존재하지 않는 경우") {
 
-            every {
-                authInfoDomainServiceMock.findByEmailAndSocialLoginProvider(
-                    userAuthInfoFixture.email,
-                    userAuthInfoFixture.socialLoginProvider
-                )
-            } returns null
+            every { authInfoDomainServiceMock.findByEmail(userAuthInfoFixture.email) } returns null
 
-            it("회원 가입 토큰을 응답한다") {
-                // arrange
-                val socialLoginProvider = SocialLoginProvider.KAKAO
-                val idToken = "idToken"
-                val command = UserSocialLoginUseCase.Command(
-                    socialLoginProvider = socialLoginProvider,
-                    idToken = idToken,
-                )
+            enumValues<SocialLoginProvider>().forEach { socialLoginProvider ->
 
-                // act
-                val result: UserSocialLoginUseCase.Result = sut.invoke(command)
+                it("회원 가입 토큰을 응답한다 : ${socialLoginProvider.name}") {
+                    // arrange
+                    val idToken = "idToken"
+                    val command = UserSocialLoginUseCase.Command(
+                        socialLoginProvider = socialLoginProvider,
+                        idToken = idToken,
+                    )
 
-                // assert
-                result.shouldBeTypeOf<UserSocialLoginUseCase.Result.NotRegistered>()
-                result.registerToken.shouldBeTypeOf<String>()
+                    // act
+                    val result: UserSocialLoginUseCase.Result = sut.invoke(command)
+
+                    // assert
+                    result.shouldBeTypeOf<UserSocialLoginUseCase.Result.NotRegistered>()
+                    result.registerToken.shouldBeTypeOf<String>()
+                }
             }
 
         }
-
 
     }
 

--- a/application/src/test/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationServiceTest.kt
@@ -1,0 +1,87 @@
+package com.studentcenter.weave.application.service.application
+
+import com.studentcenter.weave.application.port.inbound.UserSocialLoginUseCase
+import com.studentcenter.weave.application.service.UserTokenServiceStub
+import com.studentcenter.weave.application.service.domain.UserAuthInfoDomainService
+import com.studentcenter.weave.application.service.domain.UserDomainServiceStub
+import com.studentcenter.weave.domain.entity.UserAuthInfo
+import com.studentcenter.weave.domain.entity.UserAuthInfoFixtureFactory
+import com.studentcenter.weave.domain.enum.SocialLoginProvider
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.types.shouldBeTypeOf
+import io.mockk.every
+import io.mockk.mockk
+
+class UserSocialLoginApplicationServiceTest : DescribeSpec({
+
+    describe("UserSocialLoginApplicationService") {
+
+        val authInfoDomainServiceMock: UserAuthInfoDomainService =
+            mockk<UserAuthInfoDomainService>()
+        val userAuthInfoFixture: UserAuthInfo = UserAuthInfoFixtureFactory.create()
+        val sut = UserSocialLoginApplicationService(
+            userTokenService = UserTokenServiceStub(),
+            userDomainService = UserDomainServiceStub(),
+            userAuthInfoDomainService = authInfoDomainServiceMock,
+        )
+
+        context("소셜 로그인 성공시") {
+
+            every {
+                authInfoDomainServiceMock.findByEmailAndSocialLoginProvider(
+                    userAuthInfoFixture.email,
+                    userAuthInfoFixture.socialLoginProvider
+                )
+            } returns UserAuthInfoFixtureFactory.create()
+
+            it("Access Token과 Refresh Token을 응답한다") {
+                // arrange
+                val socialLoginProvider = SocialLoginProvider.KAKAO
+                val idToken = "idToken"
+                val command = UserSocialLoginUseCase.Command(
+                    socialLoginProvider = socialLoginProvider,
+                    idToken = idToken,
+                )
+
+                // act
+                val result: UserSocialLoginUseCase.Result = sut.invoke(command)
+
+                // assert
+                result.shouldBeTypeOf<UserSocialLoginUseCase.Result.Success>()
+                result.accessToken.shouldBeTypeOf<String>()
+                result.refreshToken.shouldBeTypeOf<String>()
+            }
+        }
+
+        context("회원이 존재하지 않는 경우") {
+
+            every {
+                authInfoDomainServiceMock.findByEmailAndSocialLoginProvider(
+                    userAuthInfoFixture.email,
+                    userAuthInfoFixture.socialLoginProvider
+                )
+            } returns null
+
+            it("회원 가입 토큰을 응답한다") {
+                // arrange
+                val socialLoginProvider = SocialLoginProvider.KAKAO
+                val idToken = "idToken"
+                val command = UserSocialLoginUseCase.Command(
+                    socialLoginProvider = socialLoginProvider,
+                    idToken = idToken,
+                )
+
+                // act
+                val result: UserSocialLoginUseCase.Result = sut.invoke(command)
+
+                // assert
+                result.shouldBeTypeOf<UserSocialLoginUseCase.Result.NotRegistered>()
+                result.registerToken.shouldBeTypeOf<String>()
+            }
+
+        }
+
+
+    }
+
+})

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/service/UserTokenServiceStub.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/service/UserTokenServiceStub.kt
@@ -1,0 +1,61 @@
+package com.studentcenter.weave.application.service
+
+import com.studentcenter.weave.application.vo.UserTokenClaims
+import com.studentcenter.weave.domain.entity.User
+import com.studentcenter.weave.domain.entity.UserFixtureFactory
+import com.studentcenter.weave.domain.enum.SocialLoginProvider
+import com.studentcenter.weave.support.common.vo.Email
+
+class UserTokenServiceStub : UserTokenService {
+
+    private val user = UserFixtureFactory.create()
+
+    override fun resolveIdToken(
+        idToken: String,
+        provider: SocialLoginProvider
+    ): UserTokenClaims.IdToken {
+        return UserTokenClaims.IdToken(
+            nickname = user.nickname,
+            email = user.email,
+        )
+    }
+
+    override fun generateRegisterToken(
+        email: Email,
+        provider: SocialLoginProvider
+    ): String {
+        return "registerToken"
+    }
+
+    override fun resolveRegisterToken(registerToken: String): UserTokenClaims.RegisterToken {
+        return UserTokenClaims.RegisterToken(
+            nickname = user.nickname,
+            email = user.email,
+            socialLoginProvider = SocialLoginProvider.KAKAO,
+        )
+    }
+
+    override fun generateAccessToken(user: User): String {
+        return "accessToken"
+    }
+
+    override fun resolveAccessToken(accessToken: String): UserTokenClaims.AccessToken {
+        return UserTokenClaims.AccessToken(
+            userId = user.id,
+            nickname = user.nickname,
+            email = user.email,
+            avatar = user.avatar,
+        )
+    }
+
+    override fun generateRefreshToken(user: User): String {
+        return "refreshToken"
+    }
+
+    override fun resolveRefreshToken(refreshToken: String): UserTokenClaims.RefreshToken {
+        return UserTokenClaims.RefreshToken(
+            userId = user.id,
+        )
+    }
+
+}

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/service/domain/UserDomainServiceStub.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/service/domain/UserDomainServiceStub.kt
@@ -1,0 +1,13 @@
+package com.studentcenter.weave.application.service.domain
+
+import com.studentcenter.weave.domain.entity.User
+import com.studentcenter.weave.domain.entity.UserFixtureFactory
+import java.util.*
+
+class UserDomainServiceStub: UserDomainService {
+
+    override fun getById(id: UUID): User {
+        return UserFixtureFactory.create()
+    }
+
+}


### PR DESCRIPTION
## ApplicationService는 UseCase 의 구현체

Service의 의존관계가 복잡해질것을 감안해 Service레이어를 ApplicationService, DomainService로 나누었어요. 

n-layered 아키텍처에서 사용하는 Facade처럼 Application Service를 활용한다고 생각하시면 될것같아요

DomainService의 경우 해당 도메인에만 관련있는 로직(CRUD 등)을 수행하고, ApplicationService의 경우 여러 도메인의 Service를 활용해 UseCase를 구현한다고 보시면 되요

Cotroller -> ApplicationService(UseCase) -> DomainService -> Repository, Handler

ApplicationService의 경우 InboundPort인 UseCase를 구현하고,
DomainService의 경우 별도로 인터페이스가 없기때문에 DomainServiceImpl로 구현객체 따로 만들려고 생각하고있어요.

## 인터페이스를 만드는 이유

테스트 단계에서 목사용을 최소화 하고 Fake객체를 사용하기 위함이고 Fake객체를 만들기 위해서는 Fake객체를 만드려는 대상 객체의 인터페이스가 존재해야하기때문이에요.
