### PR TITLE
[WEAV-64] 로그인 기능 토큰 발급 지원모듈 개발

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/common/properties/JwtTokenProperties.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/common/properties/JwtTokenProperties.kt
@@ -1,0 +1,23 @@
+package com.studentcenter.weave.application.common.properties
+
+import com.studentcenter.weave.domain.enum.SocialLoginProvider
+import com.studentcenter.weave.support.common.vo.Url
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(value = "user.jwt")
+data class JwtTokenProperties(
+    val access: TokenProperties,
+    val refresh: TokenProperties,
+    val socialLoginProvider: Map<SocialLoginProvider, Provider>,
+) {
+
+    data class TokenProperties(
+        val expireSeconds: Long,
+        val secret: String
+    )
+
+    data class Provider(
+        val jwksUri: Url,
+    )
+
+}

--- a/buildSrc/src/main/kotlin/Version.kt
+++ b/buildSrc/src/main/kotlin/Version.kt
@@ -20,4 +20,7 @@ object Version {
 
     const val MYSQL = "8.0.33"
     const val H2 = "2.2.224"
+
+    const val AUTH0_JAVA_JWT = "4.4.0"
+    const val AUTH0_JWKS_RSA = "0.22.1"
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,9 @@ project(":support:logger").projectDir = file("support/logger")
 include(":support:mail")
 project(":support:mail").projectDir = file("support/mail")
 
+include(":support:security")
+project(":support:security").projectDir = file("support/security")
+
 // domain
 include(":domain")
 project(":domain").projectDir = file("domain")

--- a/support/security/build.gradle.kts
+++ b/support/security/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation("com.auth0:java-jwt:${Version.AUTH0_JAVA_JWT}")
+    implementation("com.auth0:jwks-rsa:${Version.AUTH0_JWKS_RSA}")
+}

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/error/JwtExpiredException.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/error/JwtExpiredException.kt
@@ -1,0 +1,3 @@
+package com.studentcenter.weave.support.security.jwt.error
+
+class JwtExpiredException(message: String? = null) : RuntimeException(message)

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/error/JwtVerificationException.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/error/JwtVerificationException.kt
@@ -1,0 +1,3 @@
+package com.studentcenter.weave.support.security.jwt.error
+
+class JwtVerificationException(message: String? = null) : RuntimeException(message)

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/util/JwtTokenProvider.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/util/JwtTokenProvider.kt
@@ -1,0 +1,95 @@
+package com.studentcenter.weave.support.security.jwt.util
+
+import com.auth0.jwk.Jwk
+import com.auth0.jwk.JwkProviderBuilder
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.exceptions.TokenExpiredException
+import com.auth0.jwt.interfaces.DecodedJWT
+import com.studentcenter.weave.support.security.jwt.error.JwtExpiredException
+import com.studentcenter.weave.support.security.jwt.error.JwtVerificationException
+import com.studentcenter.weave.support.security.jwt.vo.JwtClaims
+import java.net.URL
+import java.security.interfaces.ECPublicKey
+import java.security.interfaces.RSAPublicKey
+import java.util.concurrent.TimeUnit
+
+object JwtTokenProvider {
+
+    fun createToken(
+        jwtClaims: JwtClaims,
+        secret: String,
+    ): String {
+        return JWT
+            .create()
+            .withJWTId(jwtClaims.jti)
+            .withSubject(jwtClaims.sub)
+            .withIssuer(jwtClaims.iss)
+            .withAudience(*jwtClaims.aud?.toTypedArray() ?: arrayOf())
+            .withIssuedAt(jwtClaims.iat)
+            .withNotBefore(jwtClaims.nbf)
+            .withExpiresAt(jwtClaims.exp)
+            .withPayload(jwtClaims.customClaims)
+            .sign(Algorithm.HMAC256(secret))
+    }
+
+    fun verifyToken(
+        token: String,
+        secret: String,
+    ): Result<JwtClaims> {
+        val algorithm: Algorithm = Algorithm.HMAC256(secret)
+        return verifyToken(token, algorithm)
+    }
+
+    fun verifyJwksBasedToken(
+        token: String,
+        jwksUri: URL,
+    ): Result<JwtClaims> {
+        val provider = JwkProviderBuilder(jwksUri)
+            .cached(10, 60 * 24, TimeUnit.HOURS)
+            .rateLimited(10, 1, TimeUnit.MINUTES)
+            .build()
+        val jwt: DecodedJWT = JWT.decode(token)
+        val jwk: Jwk = provider[jwt.keyId]
+        val algorithm: Algorithm = extractAlgorithm(jwk)
+        return verifyToken(token, algorithm)
+    }
+
+    private fun extractAlgorithm(jwk: Jwk): Algorithm {
+        return when (jwk.algorithm) {
+            "ES256" -> Algorithm.ECDSA256(jwk.publicKey as ECPublicKey, null)
+            "ES384" -> Algorithm.ECDSA384(jwk.publicKey as ECPublicKey, null)
+            "ES512" -> Algorithm.ECDSA512(jwk.publicKey as ECPublicKey, null)
+            "RS256" -> Algorithm.RSA256(jwk.publicKey as RSAPublicKey, null)
+            "RS384" -> Algorithm.RSA384(jwk.publicKey as RSAPublicKey, null)
+            "RS512" -> Algorithm.RSA512(jwk.publicKey as RSAPublicKey, null)
+            else -> throw IllegalArgumentException("지원되지 않는 알고리즘입니다.")
+        }
+    }
+
+    private fun verifyToken(
+        token: String,
+        algorithm: Algorithm,
+    ): Result<JwtClaims> {
+        return runCatching {
+            JWT
+                .require(algorithm)
+                .build()
+                .verify(token)
+        }.mapCatching { claims ->
+            JwtClaims.from(claims)
+        }.onFailure { exception ->
+            handleException(exception)
+        }
+    }
+
+    private fun handleException(ex: Throwable): Nothing {
+        exceptionHandlerList.first { it.first.isAssignableFrom(ex::class.java) }.second.invoke(ex)
+    }
+
+    private val exceptionHandlerList = listOf<Pair<Class<out Throwable>, (Throwable) -> Nothing>>(
+        TokenExpiredException::class.java to { throw JwtExpiredException("토큰이 만료되었습니다.") },
+        Throwable::class.java to { e -> throw JwtVerificationException("토큰 유효성 검사에 실패했습니다. message=${e.message}") }
+    )
+
+}

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/vo/JwtClaims.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/vo/JwtClaims.kt
@@ -1,0 +1,80 @@
+package com.studentcenter.weave.support.security.jwt.vo
+
+import com.auth0.jwt.interfaces.DecodedJWT
+import java.time.Instant
+import java.util.*
+
+/**
+ * Represents the claims of a JSON Web Token (JWT).
+ *
+ * @property registeredClaims The registered claims of the JWT.
+ * @property customClaims The custom claims of the JWT.
+ */
+data class JwtClaims(
+    val registeredClaims: RegisteredClaims,
+    val customClaims: MutableMap<String, Any> = mutableMapOf()
+) {
+
+
+    /**
+     * Represents the registered claims defined in a JSON Web Token (JWT).
+     *
+     * @property sub The subject claim identifying the principal that is the subject of the JWT
+     * @property exp The expiration time claim that specifies the time on or after which the JWT must not be accepted for processing
+     * @property iat The issued at claim that identifies the time at which the JWT was issued
+     * @property nbf The not before claim that identifies the time before which the JWT must not be accepted for processing
+     * @property iss The issuer claim that identifies the entity that issued the JWT
+     * @property aud The audience claim that identifies the recipients for which the JWT is intended
+     * @property jti The JWT ID claim that provides a unique identifier for the JWT
+     */
+    data class RegisteredClaims(
+        val sub: String? = null,
+        val exp: Date? = Date.from(Instant.now().plusSeconds(DEFAULT_EXPIRATION_TIME_SEC)),
+        val iat: Date? = Date.from(Instant.now()),
+        val nbf: Date? = Date.from(Instant.now()),
+        val iss: String? = null,
+        val aud: List<String>? = null,
+        val jti: String? = null,
+    )
+
+    val sub: String?
+        get() = registeredClaims.sub
+    val exp: Date?
+        get() = registeredClaims.exp
+    val iat: Date?
+        get() = registeredClaims.iat
+    val nbf: Date?
+        get() = registeredClaims.nbf
+    val iss: String?
+        get() = registeredClaims.iss
+    val aud: List<String>?
+        get() = registeredClaims.aud
+    val jti: String?
+        get() = registeredClaims.jti
+
+    companion object {
+
+        const val DEFAULT_EXPIRATION_TIME_SEC: Long = 60 * 60 // 1 hour
+
+        fun from(claims: DecodedJWT): JwtClaims {
+            val registeredClaims = RegisteredClaims(
+                sub = claims.subject,
+                exp = claims.expiresAt,
+                iat = claims.issuedAt,
+                nbf = claims.notBefore,
+                iss = claims.issuer,
+                aud = claims.audience,
+                jti = claims.id,
+            )
+            val customClaims: MutableMap<String, Any> = mutableMapOf()
+            claims.claims
+                .filter { it.key !in registeredClaims::class.members.map { member -> member.name } }
+                .forEach { (key, value) ->
+                    customClaims[key] = value.`as`(Any::class.java)
+                }
+            return JwtClaims(registeredClaims, customClaims)
+        }
+
+    }
+
+}

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/vo/JwtClaimsDsl.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/vo/JwtClaimsDsl.kt
@@ -1,0 +1,96 @@
+package com.studentcenter.weave.support.security.jwt.vo
+
+import java.time.Instant
+import java.util.*
+
+/**
+ * Marks the annotated class as a DSL marker for creating JwtClaims objects.
+ */
+@DslMarker
+annotation class JwtClaimsDsl
+
+/**
+ * Builder class for creating JwtClaims objects.
+ */
+@JwtClaimsDsl
+class JwtClaimsBuilder {
+    private var registeredClaims = JwtClaims.RegisteredClaims()
+    private val customClaims = mutableMapOf<String, Any>()
+
+    /**
+     * Sets the registered claims for a JSON Web Token (JWT) using the provided DSL.
+     * ```
+     * sub: Subject
+     * exp: Expiration Time
+     * iat: Issued At
+     * nbf: Not Before
+     * iss: Issuer
+     * aud: Audience
+     * jti: JWT ID
+     * ```
+     *
+     * @param init The DSL for setting registered claims.
+     * @see JwtClaims.registeredClaims
+     **/
+    fun registeredClaims(init: RegisteredClaimsBuilder.() -> Unit) {
+        val builder = RegisteredClaimsBuilder().apply(init)
+        registeredClaims = builder.build()
+    }
+
+    /**
+     * Sets the custom claims for a JSON Web Token (JWT) using the provided DSL.
+     * ```
+     * this["customKey1"] = "customValue1"
+     * this["customKey2"] = "customValue2"
+     * ```
+     * @param block The DSL for setting custom claims.
+     * @see JwtClaims.customClaims
+     */
+    fun customClaims(block: MutableMap<String, Any>.() -> Unit) {
+        customClaims.apply(block)
+    }
+
+    fun build(): JwtClaims = JwtClaims(registeredClaims, customClaims)
+}
+
+/**
+ * A builder class that creates instances of `JwtClaims.RegisteredClaims`.
+ * The class provides methods to set the registered claims for a JSON Web Token (JWT).
+ */
+@JwtClaimsDsl
+class RegisteredClaimsBuilder {
+    var sub: String? = null
+    var exp: Date? = Date.from(Instant.now().plusSeconds(JwtClaims.DEFAULT_EXPIRATION_TIME_SEC))
+    var iat: Date? = Date.from(Instant.now())
+    var nbf: Date? = Date.from(Instant.now())
+    var iss: String? = null
+    var aud: List<String>? = null
+    var jti: String? = null
+
+    fun build(): JwtClaims.RegisteredClaims =
+        JwtClaims.RegisteredClaims(sub, exp, iat, nbf, iss, aud, jti)
+}
+
+/**
+ * Creates a new JwtClaims object using the provided DSL.
+ * ```
+ * val jwt = JwtClaims {
+ *     registeredClaims {
+ *         sub = "subject"
+ *         // ... Set Registered Claim ...
+ *     }
+ *     customClaims {
+ *         this["customKey1"] = "customValue1"
+ *         // ... Set Custom Claim ...
+ *     }
+ * }
+ * ```
+ * @param init The DSL for creating a JwtClaims object.
+ * @return A new JwtClaims object.
+ * @see JwtClaimsBuilder
+ * @see JwtClaimsDsl
+ * @see RegisteredClaimsBuilder
+ * @example
+ *
+ */
+fun JwtClaims(init: JwtClaimsBuilder.() -> Unit): JwtClaims = JwtClaimsBuilder().apply(init).build()

--- a/support/security/src/test/kotlin/com/studentcenter/weave/support/security/jwt/util/JwtTokenProviderTest.kt
+++ b/support/security/src/test/kotlin/com/studentcenter/weave/support/security/jwt/util/JwtTokenProviderTest.kt
@@ -1,0 +1,146 @@
+package com.studentcenter.weave.support.security.jwt.util
+
+import com.auth0.jwt.JWT
+import com.studentcenter.weave.support.security.jwt.error.JwtExpiredException
+import com.studentcenter.weave.support.security.jwt.error.JwtVerificationException
+import com.studentcenter.weave.support.security.jwt.vo.JwtClaims
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.util.*
+
+class JwtTokenProviderTest : DescribeSpec({
+
+    describe("createToken(jwksClaims, secret)") {
+
+        context("유효한 secret key가 전달되면") {
+
+            val secret = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabc"
+
+            it("해당 secret으로 서명된 토큰을 발급한다.") {
+                // arrange
+                val claims = JwtClaims {
+                    registeredClaims {
+                        sub = "sub"
+                        aud = listOf("aud1", "aud2")
+                    }
+                    customClaims {
+                        this["key"] = "value"
+                        this["list"] = listOf("a", "b", "c")
+                    }
+                }
+
+                // act
+                val token: String = JwtTokenProvider.createToken(
+                    jwtClaims = claims,
+                    secret = secret,
+                )
+
+                // assert
+                val body = JWT.decode(token)
+                val jwtClaims = JwtClaims.from(body)
+
+                jwtClaims.sub shouldBe "sub"
+                jwtClaims.aud shouldBe setOf("aud1", "aud2")
+                jwtClaims.customClaims["key"] shouldBe "value"
+                jwtClaims.customClaims["list"] shouldBe listOf("a", "b", "c")
+            }
+        }
+
+    }
+
+    describe("verifyToken(token, secret)") {
+
+        context("유효한 secret키가 전달되면") {
+
+            val secret = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabc"
+
+            it("해당 secret으로 서명된 토큰을 복호화한다.") {
+                // arrange
+                val claims = JwtClaims {
+                    registeredClaims {
+                        sub = "sub"
+                        aud = listOf("aud1", "aud2")
+                    }
+                    customClaims {
+                        this["key"] = "value"
+                        this["list"] = listOf("a", "b", "c")
+                    }
+                }
+                val token: String = JwtTokenProvider.createToken(
+                    jwtClaims = claims,
+                    secret = secret,
+                )
+
+                // act
+                val result = runCatching {
+                    JwtTokenProvider.verifyToken(token, secret)
+                }.exceptionOrNull()
+
+                // assert
+                result shouldBe null
+            }
+        }
+
+        context("토큰이 서명된 secret과 다른 secret이 주어지면") {
+
+            val secret = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabc"
+            val anotherKey = "testtestetesttestetesttestetesttestetesttestetesttestetestteste"
+
+            it("JwtVerificationException을 발생시킨다.") {
+                // arrange
+                val token: String = JwtTokenProvider.createToken(
+                    jwtClaims = JwtClaims {
+                        registeredClaims {
+                            sub = "sub"
+                            aud = listOf("aud1", "aud2")
+                        }
+                        customClaims {
+                            this["key"] = "value"
+                        }
+                    },
+                    secret = secret,
+                )
+
+                // act
+                val result = runCatching {
+                    JwtTokenProvider.verifyToken(token, anotherKey)
+                }.exceptionOrNull()
+
+                // assert
+                result.shouldBeInstanceOf<JwtVerificationException>()
+            }
+        }
+
+        context("만료된 토큰이 주어지면") {
+
+            val secret = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabc"
+
+            it("JwtExpiredException 예외를 발생시킨다") {
+                // arrange
+                val token: String = JwtTokenProvider.createToken(
+                    jwtClaims = JwtClaims {
+                        registeredClaims {
+                            sub = "sub"
+                            aud = listOf("aud1", "aud2")
+                            exp = Date.from(Date().toInstant().minusSeconds(1))
+                        }
+                        customClaims {
+                            this["key"] = "value"
+                        }
+                    },
+                    secret = secret,
+                )
+
+                // act
+                val result = runCatching {
+                    JwtTokenProvider.verifyToken(token, secret)
+                }.exceptionOrNull()
+
+                // assert
+                result.shouldBeInstanceOf<JwtExpiredException>()
+            }
+        }
+    }
+
+})


### PR DESCRIPTION
토큰 resolve를 위한 auth0라이브러리의 래핑을 위해 아래 내용은 support/security 라는 모듈을 따로 만들어 개발해두었습니다. 

## JwtTokenProvider
JwtTokenProvider는 외부 의존성 주입받아 사용하지 않고, Spring생명주기가 필요없기때문에 공통모듈에 유틸리티 클래스로 만들어두었어요.

## JwtTokenClaims
JwtClaims는 코틀린 DSL활용해서 생성할 수 있게끔 정의해 두었어요.

## JwtTokenProvider - verifyJwksBasedToken

JwtTokenProvider의 Jwks Uri를 통해 resolve하는 로직은 어떻게 테스트 할지 고민중이에요.(verifyJwksBasedToken 함수)

해당 함수의 경우 카카오측에서 private key로 서명한 idToken을 카카오의 jwks uri로 전달받을수 있는 public key로 토큰에 대한 검증을 할 수 있는데, 

```kotlin
    fun verifyJwksBasedToken(
        token: String,
        jwksUri: URL,
    ): Result<JwtClaims> {
        val provider = JwkProviderBuilder(jwksUri)
            .cached(10, 60 * 24, TimeUnit.HOURS)
            .rateLimited(10, 1, TimeUnit.MINUTES)
            .build()
        val jwt: DecodedJWT = JWT.decode(token)
        val jwk: Jwk = provider[jwt.keyId]
        val algorithm: Algorithm = extractAlgorithm(jwk)
        return verifyToken(token, algorithm)
    }
```

위 코드의 JwkProviderBuilder가 전달받은 URL로 직접 외부요청을 하기 때문에 테스트 하기가 애매한 부분이 있네요. -> wiremock을 적용할까 싶었는데, 별거아닌기능에 너무 집중하는것 같아서 일단 테스트 없이 뒀습니다.

## URL VO 관련

별개로 java.net에 URL객체가 있는걸 몰랐네요. Spring에만 URL있는줄 알았는데, Url VO 없애고 URL객체 사용하는게 좋겠어요.


## 이후 구현방향에 대해

UserTokenService인터페이스를 구현해야하는데 애플리케이션 레이어에 구현할지, 인프라 레이어에 구현할지 고민이네요.

비즈니스와 연관성 있는듯 하면서도, 소셜로그인 제공자별 claim 매핑까지 비즈니스의 영역인가? 싶은 생각이들어서 UserTokenHandler라는 Port로 만들고 인프라레이어에 별도로 Jwt 모듈을 만들지 고민이에요

feat/WEAV-65 브랜치에 언급한 형태로 구현해두었습니다.
