### PR TITLE
[WEAV-70] 소셜 로그인 API, 회원가입 필요 응답 상태코드 401 명세

### DIFF
--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/AuthApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/AuthApi.kt
@@ -6,8 +6,13 @@ import com.studentcenter.weave.bootstrap.adapter.dto.SocialLoginRequest
 import com.studentcenter.weave.bootstrap.adapter.dto.SocialLoginResponse
 import com.studentcenter.weave.domain.enum.SocialLoginProvider
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -20,11 +25,38 @@ interface AuthApi {
 
     @Operation(summary = "Social Login")
     @PostMapping("/login/{provider}")
-    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "로그인 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = SocialLoginResponse.Success::class
+                        )
+                    ),
+                ]
+            ),
+            ApiResponse(
+                responseCode = "202",
+                description = "로그인 성공(회원가입 필요)",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = SocialLoginResponse.UserNotRegistered::class
+                        )
+                    ),
+                ]
+            ),
+        ]
+    )
     fun socialLogin(
         @PathVariable provider: SocialLoginProvider,
         @RequestBody request: SocialLoginRequest,
-    ): SocialLoginResponse
+    ): ResponseEntity<SocialLoginResponse>
 
     @Operation(summary = "Refresh Login Token")
     @PostMapping("/refresh")

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/AuthApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/AuthApi.kt
@@ -40,8 +40,8 @@ interface AuthApi {
                 ]
             ),
             ApiResponse(
-                responseCode = "202",
-                description = "로그인 성공(회원가입 필요)",
+                responseCode = "401",
+                description = "회원가입 필요",
                 content = [
                     Content(
                         mediaType = "application/json",

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/AuthRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/AuthRestController.kt
@@ -6,6 +6,7 @@ import com.studentcenter.weave.bootstrap.adapter.dto.RefreshTokenRequest
 import com.studentcenter.weave.bootstrap.adapter.dto.SocialLoginRequest
 import com.studentcenter.weave.bootstrap.adapter.dto.SocialLoginResponse
 import com.studentcenter.weave.domain.enum.SocialLoginProvider
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -14,11 +15,12 @@ class AuthRestController : AuthApi {
     override fun socialLogin(
         provider: SocialLoginProvider,
         request: SocialLoginRequest,
-    ): SocialLoginResponse {
-        return SocialLoginResponse.Success(
+    ): ResponseEntity<SocialLoginResponse> {
+        val success = SocialLoginResponse.Success(
             accessToken = "test_access_token",
             refreshToken = "test_refresh_token",
         )
+        return ResponseEntity.ok(success)
     }
 
     override fun refreshLoginToken(


### PR DESCRIPTION
클라이언트측 요청 사항 반영이에요


```
문장훈 — 어제 오후 10:29
@서버 
소셜 로그인 API 호출 시 회원가입 되어있는 경우만 테스트 가능해서
registerToken이 오는 경우는 어떻게 구분할 수 있는지 필요합니다. 
ex. 상태코드 
```

회원가입 필요한 경우 Http 기본 상태코드중 401로 응답하도록 처리했어요.

