### PR TITLE
[WEAV-72] ✨ 예외처리 핸들러 구현

### DIFF
--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/ApiExceptionType.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/ApiExceptionType.kt
@@ -1,0 +1,8 @@
+package com.studentcenter.weave.bootstrap.common.exception
+
+import com.studentcenter.weave.support.common.exception.CustomExceptionType
+
+enum class ApiExceptionType(override val code: String) : CustomExceptionType {
+    INVALID_DATE_EXCEPTION("API-001"),
+    INVALID_PARAMETER("API-002"),
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/CustomExceptionHandler.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/CustomExceptionHandler.kt
@@ -1,10 +1,8 @@
 package com.studentcenter.weave.bootstrap.common.exception
 
 import com.studentcenter.weave.support.common.exception.CustomException
-import com.studentcenter.weave.support.common.exception.SystemExceptionType
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.Hidden
-import jakarta.servlet.http.HttpServletRequest
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.http.HttpStatus
@@ -63,7 +61,10 @@ class CustomExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     fun handleRequestValidException(exception: MethodArgumentNotValidException): ErrorResponse {
         val builder = StringBuilder()
-        for (fieldError in exception.bindingResult.fieldErrors) {
+        exception
+            .bindingResult
+            .fieldErrors
+            .forEach { fieldError ->
             builder
                 .append("[${fieldError.field}](은)는 ${fieldError.defaultMessage}")
                 .append("입력된 값: ${fieldError.rejectedValue}")
@@ -73,19 +74,6 @@ class CustomExceptionHandler {
         return ErrorResponse(
             exceptionCode = ApiExceptionType.INVALID_PARAMETER.code,
             message = message.substring(0, message.lastIndexOf("|")),
-        )
-    }
-
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(RuntimeException::class)
-    fun handleApiException(
-        exception: RuntimeException,
-        request: HttpServletRequest
-    ): ErrorResponse {
-        logger.error { exception.stackTraceToString() }
-        return ErrorResponse(
-            exceptionCode = SystemExceptionType.RUNTIME_EXCEPTION.code,
-            message = "Internal Server Error",
         )
     }
 

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/CustomExceptionHandler.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/CustomExceptionHandler.kt
@@ -1,0 +1,92 @@
+package com.studentcenter.weave.bootstrap.common.exception
+
+import com.studentcenter.weave.support.common.exception.CustomException
+import com.studentcenter.weave.support.common.exception.SystemExceptionType
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.swagger.v3.oas.annotations.Hidden
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.HttpRequestMethodNotSupportedException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import java.time.DateTimeException
+
+@Hidden
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class CustomExceptionHandler {
+
+    private val logger = KotlinLogging.logger { }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(CustomException::class)
+    fun handleApiException(exception: CustomException): ErrorResponse {
+        return ErrorResponse(
+            exceptionCode = exception.type.code,
+            message = exception.message,
+        )
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(DateTimeException::class)
+    fun handleDateTimeException(exception: DateTimeException): ErrorResponse {
+        return ErrorResponse(
+            exceptionCode = ApiExceptionType.INVALID_DATE_EXCEPTION.code,
+            message = exception.message!!,
+        )
+    }
+
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    fun handleHttpMethodNotSupportedException(exception: HttpRequestMethodNotSupportedException): ErrorResponse {
+        return ErrorResponse(
+            exceptionCode = ApiExceptionType.INVALID_PARAMETER.code,
+            message = "지원하지 않는 Http Method 입니다.",
+        )
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMethodNotReadableException(exception: HttpMessageNotReadableException): ErrorResponse {
+        return ErrorResponse(
+            exceptionCode = ApiExceptionType.INVALID_PARAMETER.code,
+            message = "잘못된 HttpBody 형식입니다.",
+        )
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleRequestValidException(exception: MethodArgumentNotValidException): ErrorResponse {
+        val builder = StringBuilder()
+        for (fieldError in exception.bindingResult.fieldErrors) {
+            builder
+                .append("[${fieldError.field}](은)는 ${fieldError.defaultMessage}")
+                .append("입력된 값: ${fieldError.rejectedValue}")
+                .append("|")
+        }
+        val message = builder.toString()
+        return ErrorResponse(
+            exceptionCode = ApiExceptionType.INVALID_PARAMETER.code,
+            message = message.substring(0, message.lastIndexOf("|")),
+        )
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(RuntimeException::class)
+    fun handleApiException(
+        exception: RuntimeException,
+        request: HttpServletRequest
+    ): ErrorResponse {
+        logger.error { exception.stackTraceToString() }
+        return ErrorResponse(
+            exceptionCode = SystemExceptionType.RUNTIME_EXCEPTION.code,
+            message = "Internal Server Error",
+        )
+    }
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/ErrorResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/ErrorResponse.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.bootstrap.common.exception
+
+import java.time.LocalDateTime
+
+data class ErrorResponse(
+    val exceptionCode: String,
+    val message: String,
+    val timeStamp: LocalDateTime = LocalDateTime.now(),
+)

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/UnknownExceptionHandler.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/UnknownExceptionHandler.kt
@@ -1,0 +1,34 @@
+package com.studentcenter.weave.bootstrap.common.exception
+
+import com.studentcenter.weave.support.common.exception.SystemExceptionType
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.swagger.v3.oas.annotations.Hidden
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@Hidden
+@RestControllerAdvice
+@Order(value = Ordered.HIGHEST_PRECEDENCE + 1)
+class UnknownExceptionHandler {
+
+    private val logger = KotlinLogging.logger { }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Throwable::class)
+    fun handleApiException(
+        e: Throwable,
+        request: HttpServletRequest
+    ): ErrorResponse {
+        logger.error { e.stackTraceToString() }
+
+        return ErrorResponse(
+            exceptionCode = SystemExceptionType.INTERNAL_SERVER_ERROR.code,
+            message = "Internal Server Error"
+        )
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,8 @@ subprojects {
     apply(plugin = "io.spring.dependency-management")
 
     dependencies {
+        implementation("io.github.oshai:kotlin-logging-jvm:${Version.KOTLIN_LOGGING}")
+
         implementation("org.jetbrains.kotlin:kotlin-stdlib:${Version.KOTLIN}")
         implementation("org.jetbrains.kotlin:kotlin-reflect:${Version.KOTLIN}")
 

--- a/buildSrc/src/main/kotlin/Version.kt
+++ b/buildSrc/src/main/kotlin/Version.kt
@@ -25,4 +25,6 @@ object Version {
     const val AUTH0_JWKS_RSA = "0.22.1"
 
     const val FLYWAY = "10.6.0"
+
+    const val KOTLIN_LOGGING = "5.1.0"
 }

--- a/support/common/src/main/kotlin/com/studentcenter/weave/support/common/exception/CustomException.kt
+++ b/support/common/src/main/kotlin/com/studentcenter/weave/support/common/exception/CustomException.kt
@@ -1,0 +1,6 @@
+package com.studentcenter.weave.support.common.exception
+
+class CustomException(
+    val type: CustomExceptionType,
+    override val message: String
+) : RuntimeException(message)

--- a/support/common/src/main/kotlin/com/studentcenter/weave/support/common/exception/CustomExceptionType.kt
+++ b/support/common/src/main/kotlin/com/studentcenter/weave/support/common/exception/CustomExceptionType.kt
@@ -1,0 +1,5 @@
+package com.studentcenter.weave.support.common.exception
+
+interface CustomExceptionType {
+    val code: String
+}

--- a/support/common/src/main/kotlin/com/studentcenter/weave/support/common/exception/SystemExceptionType.kt
+++ b/support/common/src/main/kotlin/com/studentcenter/weave/support/common/exception/SystemExceptionType.kt
@@ -1,0 +1,6 @@
+package com.studentcenter.weave.support.common.exception
+
+enum class SystemExceptionType(override val code: String) : CustomExceptionType {
+    INTERNAL_SERVER_ERROR("SYSTEM-000"),
+    RUNTIME_EXCEPTION("SYSTEM-001")
+}

--- a/support/security/build.gradle.kts
+++ b/support/security/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
+    implementation(project(":support:common"))
     implementation("com.auth0:java-jwt:${Version.AUTH0_JAVA_JWT}")
     implementation("com.auth0:jwks-rsa:${Version.AUTH0_JWKS_RSA}")
 }

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/error/JwtExpiredException.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/error/JwtExpiredException.kt
@@ -1,3 +1,0 @@
-package com.studentcenter.weave.support.security.jwt.error
-
-class JwtExpiredException(message: String? = null) : RuntimeException(message)

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/error/JwtVerificationException.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/error/JwtVerificationException.kt
@@ -1,3 +1,0 @@
-package com.studentcenter.weave.support.security.jwt.error
-
-class JwtVerificationException(message: String? = null) : RuntimeException(message)

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/exception/JwtExceptionType.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/jwt/exception/JwtExceptionType.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.support.security.jwt.exception
+
+import com.studentcenter.weave.support.common.exception.CustomExceptionType
+
+enum class JwtExceptionType(override val code: String) : CustomExceptionType {
+    JWT_DECODE_EXCEPTION("JWT-001"),
+    JWT_EXPIRED_EXCEPTION("JWT-002"),
+    JWT_VERIFICATION_EXCEPTION("JWT-003"),
+}

--- a/support/security/src/test/kotlin/com/studentcenter/weave/support/security/jwt/util/JwtTokenProviderTest.kt
+++ b/support/security/src/test/kotlin/com/studentcenter/weave/support/security/jwt/util/JwtTokenProviderTest.kt
@@ -1,8 +1,8 @@
 package com.studentcenter.weave.support.security.jwt.util
 
 import com.auth0.jwt.JWT
-import com.studentcenter.weave.support.security.jwt.error.JwtExpiredException
-import com.studentcenter.weave.support.security.jwt.error.JwtVerificationException
+import com.studentcenter.weave.support.common.exception.CustomException
+import com.studentcenter.weave.support.security.jwt.exception.JwtExceptionType
 import com.studentcenter.weave.support.security.jwt.vo.JwtClaims
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -87,7 +87,7 @@ class JwtTokenProviderTest : DescribeSpec({
             val secret = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabc"
             val anotherKey = "testtestetesttestetesttestetesttestetesttestetesttestetestteste"
 
-            it("JwtVerificationException을 발생시킨다.") {
+            it("BadRequestException 을 발생시킨다.") {
                 // arrange
                 val token: String = JwtTokenProvider.createToken(
                     jwtClaims = JwtClaims {
@@ -108,7 +108,8 @@ class JwtTokenProviderTest : DescribeSpec({
                 }.exceptionOrNull()
 
                 // assert
-                result.shouldBeInstanceOf<JwtVerificationException>()
+                result.shouldBeInstanceOf<CustomException>()
+                result.type shouldBe JwtExceptionType.JWT_DECODE_EXCEPTION
             }
         }
 
@@ -116,7 +117,7 @@ class JwtTokenProviderTest : DescribeSpec({
 
             val secret = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabc"
 
-            it("JwtExpiredException 예외를 발생시킨다") {
+            it("CustomException 예외를 발생시킨다") {
                 // arrange
                 val token: String = JwtTokenProvider.createToken(
                     jwtClaims = JwtClaims {
@@ -138,7 +139,8 @@ class JwtTokenProviderTest : DescribeSpec({
                 }.exceptionOrNull()
 
                 // assert
-                result.shouldBeInstanceOf<JwtExpiredException>()
+                result.shouldBeInstanceOf<CustomException>()
+                result.type shouldBe JwtExceptionType.JWT_EXPIRED_EXCEPTION
             }
         }
     }


### PR DESCRIPTION
## 구현사항

매번 예외 클래스 만들고, 해당 예외 클래스에 대한 처리를 담당할 ExceptionHandler 함수를 추가하는 번거로움을 없애기 위해 CustomException을 구현했어요.

```kotlin
class CustomException(
    val type: CustomExceptionType,
    override val message: String
) : RuntimeException(message)
```

CustomException간의 구분은 CustomExceptionType을 상속한 enum class를 만들어서 파라미터로 주입받아 CustomException의 속성으로 구분할 수 있어요. (ref. JwtExceptionType)

위와 같이 일관되게 CustomException으로 처리했을때 응답코드가 모두 400이라는 단점이 있지만, 

```kotlin
data class ErrorResponse(
    val exceptionCode: String,
    val message: String,
    val timeStamp: LocalDateTime = LocalDateTime.now(),
)
```

ErrorResponse(예외응답 스키마)의 exceptionCode를 통해 어떤 종류의 예외인지 파악할 수 있고, 클라이언트에게 명세할때에도 enum class를 그대로 전달하면 되기때문에 문서화 측면에서도 편리하다고 생각해요.


## 이전 내용 수정사항
위의 변경에 따라 :support:security 모듈의 JwtTokenProvider의 예외처리를 일부 수정하고 이에따라 테스트도 수정했어요.