### PR TITLE
[WEAV-121] UserJpaEntity 구현

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/port/inbound/UserRegisterUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/port/inbound/UserRegisterUseCase.kt
@@ -4,10 +4,9 @@ import com.studentcenter.weave.domain.enum.Gender
 import com.studentcenter.weave.domain.enum.Mbti
 import com.studentcenter.weave.domain.enum.SocialLoginProvider
 import com.studentcenter.weave.domain.vo.BirthYear
-import com.studentcenter.weave.domain.vo.MajorName
 import com.studentcenter.weave.domain.vo.Nickname
-import com.studentcenter.weave.domain.vo.UniversityName
 import com.studentcenter.weave.support.common.vo.Email
+import java.util.*
 
 fun interface UserRegisterUseCase {
 
@@ -20,8 +19,8 @@ fun interface UserRegisterUseCase {
         val gender: Gender,
         val mbti: Mbti,
         val birthYear: BirthYear,
-        val university: UniversityName,
-        val major: MajorName
+        val universityId: UUID,
+        val majorId: UUID,
     )
 
     sealed class Result {

--- a/application/src/main/kotlin/com/studentcenter/weave/application/port/outbound/UserRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/port/outbound/UserRepository.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.application.port.outbound
+
+import com.studentcenter.weave.domain.entity.User
+
+interface UserRepository {
+
+    fun save(user: User)
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/UserRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/UserRestController.kt
@@ -24,8 +24,8 @@ class UserRestController(
             gender = request.gender,
             mbti = request.mbti,
             birthYear = request.birthYear,
-            university = request.university,
-            major = request.major,
+            universityId = request.universityId,
+            majorId = request.majorId,
         )
 
         return when (val result: UserRegisterUseCase.Result = userRegisterUseCase.invoke(command)) {

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/RegisterUserRequest.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/RegisterUserRequest.kt
@@ -3,9 +3,8 @@ package com.studentcenter.weave.bootstrap.adapter.dto
 import com.studentcenter.weave.domain.enum.Gender
 import com.studentcenter.weave.domain.enum.Mbti
 import com.studentcenter.weave.domain.vo.BirthYear
-import com.studentcenter.weave.domain.vo.MajorName
-import com.studentcenter.weave.domain.vo.UniversityName
 import io.swagger.v3.oas.annotations.media.Schema
+import java.util.*
 
 @Schema(
     name = "Register User Request",
@@ -15,6 +14,6 @@ data class RegisterUserRequest(
     val gender: Gender,
     val birthYear: BirthYear,
     val mbti: Mbti,
-    val university: UniversityName,
-    val major: MajorName,
+    val universityId: UUID,
+    val majorId: UUID,
 )

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/entity/User.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/entity/User.kt
@@ -3,9 +3,7 @@ package com.studentcenter.weave.domain.entity
 import com.studentcenter.weave.domain.enum.Gender
 import com.studentcenter.weave.domain.enum.Mbti
 import com.studentcenter.weave.domain.vo.BirthYear
-import com.studentcenter.weave.domain.vo.MajorName
 import com.studentcenter.weave.domain.vo.Nickname
-import com.studentcenter.weave.domain.vo.UniversityName
 import com.studentcenter.weave.support.common.uuid.UuidCreator
 import com.studentcenter.weave.support.common.vo.Email
 import com.studentcenter.weave.support.common.vo.Url
@@ -19,8 +17,8 @@ data class User(
     val gender: Gender,
     val mbti: Mbti,
     val birthYear: BirthYear,
-    val university: UniversityName,
-    val major: MajorName,
+    val universityId: UUID,
+    val majorId: UUID,
     val avatar: Url? = null,
     val registeredAt: LocalDateTime = LocalDateTime.now(),
     val updatedAt: LocalDateTime = LocalDateTime.now(),
@@ -28,14 +26,15 @@ data class User(
 
 
     companion object {
+
         fun create(
             nickname: Nickname,
             email: Email,
             gender: Gender,
             mbti: Mbti,
             birthYear: BirthYear,
-            university: UniversityName,
-            major: MajorName,
+            universityId: UUID,
+            majorId: UUID,
             avatar: Url? = null,
         ): User {
             return User(
@@ -44,8 +43,8 @@ data class User(
                 gender = gender,
                 mbti = mbti,
                 birthYear = birthYear,
-                university = university,
-                major = major,
+                universityId = universityId,
+                majorId = majorId,
                 avatar = avatar,
             )
         }

--- a/domain/src/test/kotlin/com/studentcenter/weave/domain/entity/UserTest.kt
+++ b/domain/src/test/kotlin/com/studentcenter/weave/domain/entity/UserTest.kt
@@ -3,9 +3,8 @@ package com.studentcenter.weave.domain.entity
 import com.studentcenter.weave.domain.enum.Gender
 import com.studentcenter.weave.domain.enum.Mbti
 import com.studentcenter.weave.domain.vo.BirthYear
-import com.studentcenter.weave.domain.vo.MajorName
 import com.studentcenter.weave.domain.vo.Nickname
-import com.studentcenter.weave.domain.vo.UniversityName
+import com.studentcenter.weave.support.common.uuid.UuidCreator
 import com.studentcenter.weave.support.common.vo.Email
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -18,8 +17,8 @@ class UserTest : FunSpec({
         val email = Email("test@test.com")
         val gender = Gender.MAN
         val birthYear = BirthYear(1999)
-        val university = UniversityName("서울대학교")
-        val major = MajorName("컴퓨터 공학과")
+        val universityId = UuidCreator.create()
+        val majorId = UuidCreator.create()
         val mbti = Mbti.ENFJ
 
         // act
@@ -29,8 +28,8 @@ class UserTest : FunSpec({
             gender = gender,
             mbti = mbti,
             birthYear = birthYear,
-            university = university,
-            major = major,
+            universityId = universityId,
+            majorId = majorId,
         )
 
         // assert
@@ -39,7 +38,8 @@ class UserTest : FunSpec({
         user.gender shouldBe gender
         user.mbti shouldBe mbti
         user.birthYear shouldBe birthYear
-        user.major shouldBe major
+        user.universityId shouldBe universityId
+        user.majorId shouldBe majorId
     }
 
 })

--- a/domain/src/testFixtures/kotlin/com/studentcenter/weave/domain/entity/UserFixtureFactory.kt
+++ b/domain/src/testFixtures/kotlin/com/studentcenter/weave/domain/entity/UserFixtureFactory.kt
@@ -4,6 +4,7 @@ import com.studentcenter.weave.domain.enum.Gender
 import com.studentcenter.weave.domain.enum.Mbti
 import com.studentcenter.weave.domain.vo.BirthYear
 import com.studentcenter.weave.domain.vo.Nickname
+import com.studentcenter.weave.support.common.uuid.UuidCreator
 import com.studentcenter.weave.support.common.vo.Email
 import com.studentcenter.weave.support.common.vo.Url
 import java.util.*
@@ -16,8 +17,8 @@ object UserFixtureFactory {
         gender: Gender = Gender.MAN,
         mbti: Mbti = Mbti.ENFJ,
         birthYear: BirthYear = BirthYear(1999),
-        universityId: UUID = UUID.randomUUID(),
-        majorId: UUID = UUID.randomUUID(),
+        universityId: UUID = UuidCreator.create(),
+        majorId: UUID = UuidCreator.create(),
         avatar: Url? = null,
     ): User {
         return User(

--- a/domain/src/testFixtures/kotlin/com/studentcenter/weave/domain/entity/UserFixtureFactory.kt
+++ b/domain/src/testFixtures/kotlin/com/studentcenter/weave/domain/entity/UserFixtureFactory.kt
@@ -3,11 +3,10 @@ package com.studentcenter.weave.domain.entity
 import com.studentcenter.weave.domain.enum.Gender
 import com.studentcenter.weave.domain.enum.Mbti
 import com.studentcenter.weave.domain.vo.BirthYear
-import com.studentcenter.weave.domain.vo.MajorName
 import com.studentcenter.weave.domain.vo.Nickname
-import com.studentcenter.weave.domain.vo.UniversityName
 import com.studentcenter.weave.support.common.vo.Email
 import com.studentcenter.weave.support.common.vo.Url
+import java.util.*
 
 object UserFixtureFactory {
 
@@ -17,8 +16,8 @@ object UserFixtureFactory {
         gender: Gender = Gender.MAN,
         mbti: Mbti = Mbti.ENFJ,
         birthYear: BirthYear = BirthYear(1999),
-        university: UniversityName = UniversityName("서울대학교"),
-        major: MajorName = MajorName("컴퓨터 공학과"),
+        universityId: UUID = UUID.randomUUID(),
+        majorId: UUID = UUID.randomUUID(),
         avatar: Url? = null,
     ): User {
         return User(
@@ -27,8 +26,8 @@ object UserFixtureFactory {
             gender = gender,
             mbti = mbti,
             birthYear = birthYear,
-            university = university,
-            major = major,
+            universityId = universityId,
+            majorId = majorId,
             avatar = avatar,
         )
     }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/adapter/UserJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/adapter/UserJpaAdapter.kt
@@ -1,0 +1,20 @@
+package com.studentcenter.weave.infrastructure.persistence.adapter
+
+import com.studentcenter.weave.application.port.outbound.UserRepository
+import com.studentcenter.weave.domain.entity.User
+import com.studentcenter.weave.infrastructure.persistence.entity.UserJpaEntity
+import com.studentcenter.weave.infrastructure.persistence.entity.UserJpaEntity.Companion.toJpaEntity
+import com.studentcenter.weave.infrastructure.persistence.repository.UserJpaRepository
+import org.springframework.stereotype.Component
+
+@Component
+class UserJpaAdapter (
+    private val userJpaRepository: UserJpaRepository
+): UserRepository {
+
+    override fun save(user: User) {
+        val userJpaEntity: UserJpaEntity = user.toJpaEntity()
+        userJpaRepository.save(userJpaEntity)
+    }
+
+}

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/entity/UserAuthInfoJpaEntity.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/entity/UserAuthInfoJpaEntity.kt
@@ -21,6 +21,7 @@ class UserAuthInfoJpaEntity(
     socialLoginProvider: SocialLoginProvider,
     registeredAt: LocalDateTime,
 ) {
+
     @Id
     var id: UUID = id
         private set
@@ -43,20 +44,17 @@ class UserAuthInfoJpaEntity(
         private set
 
     companion object {
-        fun create(
-            userId: UUID,
-            email: Email,
-            socialLoginProvider: SocialLoginProvider,
-            registeredAt: LocalDateTime,
-        ): UserAuthInfoJpaEntity {
+
+        fun UserAuthInfo.toJpaEntity(): UserAuthInfoJpaEntity {
             return UserAuthInfoJpaEntity(
-                id = UUID.randomUUID(),
+                id = id,
                 userId = userId,
                 email = email,
                 socialLoginProvider = socialLoginProvider,
                 registeredAt = registeredAt,
             )
         }
+
     }
 
     fun toDomain(): UserAuthInfo {

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/entity/UserJpaEntity.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/entity/UserJpaEntity.kt
@@ -1,0 +1,100 @@
+package com.studentcenter.weave.infrastructure.persistence.entity
+
+import com.studentcenter.weave.domain.entity.User
+import com.studentcenter.weave.domain.enum.Gender
+import com.studentcenter.weave.domain.enum.Mbti
+import com.studentcenter.weave.domain.vo.BirthYear
+import com.studentcenter.weave.domain.vo.Nickname
+import com.studentcenter.weave.support.common.vo.Email
+import com.studentcenter.weave.support.common.vo.Url
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import java.util.*
+
+@Entity
+@Table(name = "`user`")
+class UserJpaEntity(
+    id: UUID,
+    nickname: Nickname,
+    email: Email,
+    gender: Gender,
+    mbti: Mbti,
+    birthYear: BirthYear,
+    universityId: UUID,
+    majorId: UUID,
+    avatar: Url? = null,
+    registeredAt: LocalDateTime,
+    updatedAt: LocalDateTime,
+) {
+
+    @Id
+    @Column(nullable = false, updatable = false)
+    var id: UUID = id
+        private set
+
+    @Column(nullable = false, updatable = false)
+    var nickname: Nickname = nickname
+        private set
+
+    @Column(nullable = false, updatable = false)
+    var email: Email = email
+        private set
+
+    @Column(nullable = false, updatable = false, columnDefinition = "varchar(255)")
+    @Enumerated(value = EnumType.STRING)
+    var gender: Gender = gender
+        private set
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    @Enumerated(value = EnumType.STRING)
+    var mbti: Mbti = mbti
+        private set
+
+    @Column(nullable = false)
+    var birthYear: BirthYear = birthYear
+        private set
+
+    @Column(nullable = false, updatable = false)
+    var universityId: UUID = universityId
+        private set
+
+    @Column(nullable = false, updatable = false)
+    var majorId: UUID = majorId
+        private set
+
+    @Column()
+    var avatar: Url? = avatar
+        private set
+
+    @Column(nullable = false, updatable = false)
+    var registeredAt: LocalDateTime = registeredAt
+        private set
+
+    @Column(nullable = false)
+    var updatedAt: LocalDateTime = updatedAt
+        private set
+
+    companion object {
+        fun User.toJpaEntity(): UserJpaEntity {
+            return UserJpaEntity(
+                id = id,
+                nickname = nickname,
+                email = email,
+                gender = gender,
+                mbti = mbti,
+                birthYear = birthYear,
+                universityId = universityId,
+                majorId = majorId,
+                avatar = avatar,
+                registeredAt = registeredAt,
+                updatedAt = updatedAt,
+            )
+        }
+    }
+
+}

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/repository/UserJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/repository/UserJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.infrastructure.persistence.repository
+
+import com.studentcenter.weave.infrastructure.persistence.entity.UserJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface UserJpaRepository : JpaRepository<UserJpaEntity, UUID>

--- a/infrastructure/persistence/src/main/resources/application-persistence.yaml
+++ b/infrastructure/persistence/src/main/resources/application-persistence.yaml
@@ -20,6 +20,9 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: true
+  flyway:
+    clean-disabled: false
+    clean-on-validation-error: true
 ---
 spring:
   config:

--- a/infrastructure/persistence/src/main/resources/db/migration/V3__create_user.sql
+++ b/infrastructure/persistence/src/main/resources/db/migration/V3__create_user.sql
@@ -1,0 +1,19 @@
+-- 유저 --
+create table `user`
+(
+    id            binary(16)   not null,
+    nickname      varchar(255) not null,
+    email         varchar(255) not null,
+    gender        varchar(255) not null,
+    mbti          varchar(255) not null,
+    birth_year    integer      not null,
+    university_id binary(16)   not null,
+    major_id      binary(16)   not null,
+    avatar        varchar(255),
+    registered_at datetime(6)  not null,
+    updated_at    datetime(6)  not null,
+    primary key (`id`),
+    index idx_university_id (university_id),
+    index idx_major_id (major_id)
+) engine = InnoDB
+  default charset = utf8mb4;

--- a/infrastructure/persistence/src/main/resources/db/migration/V3__create_user.sql
+++ b/infrastructure/persistence/src/main/resources/db/migration/V3__create_user.sql
@@ -12,7 +12,7 @@ create table `user`
     avatar        varchar(255),
     registered_at datetime(6)  not null,
     updated_at    datetime(6)  not null,
-    primary key (`id`),
+    primary key (id),
     index idx_university_id (university_id),
     index idx_major_id (major_id)
 ) engine = InnoDB


### PR DESCRIPTION
## 구현사항
- major, university 엔티티 추가에따른 user 연관관계 필드 id값으로 변경(majorId, universityId)
- UserJpaRepository, UserJpaAdapter, UserJpaEntity 구현
- user 테이블 DDL 정의, 외래키의 경우 직접적으로 FK설정하지 않고 secondary index만 걸어둠

## 논의사항
- local에서는 validation에러시 flyway history 자동으로 지우게 만들면 어떨까요?, 
- 로컬에서 개발할때, DB스키마 수정하면서 개발하는데 docker compose down시켰다 다시올리기 번거로운것 같아요.
- 테스트서버, 프로덕션에서만 아래 옵션 사용안하면 큰문제 없을것 같아요,

```
  flyway:
    clean-disabled: false
    clean-on-validation-error: true
```