### PR TITLE
[WEAV-124] 유저 JPA 어댑터 getById 구현

### DIFF
--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/adapter/UserJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/adapter/UserJpaAdapter.kt
@@ -2,16 +2,18 @@ package com.studentcenter.weave.infrastructure.persistence.adapter
 
 import com.studentcenter.weave.application.port.outbound.UserRepository
 import com.studentcenter.weave.domain.entity.User
+import com.studentcenter.weave.infrastructure.persistence.common.exception.PersistenceExceptionType
 import com.studentcenter.weave.infrastructure.persistence.entity.UserJpaEntity
 import com.studentcenter.weave.infrastructure.persistence.entity.UserJpaEntity.Companion.toJpaEntity
 import com.studentcenter.weave.infrastructure.persistence.repository.UserJpaRepository
+import com.studentcenter.weave.support.common.exception.CustomException
 import org.springframework.stereotype.Component
 import java.util.*
 
 @Component
-class UserJpaAdapter (
+class UserJpaAdapter(
     private val userJpaRepository: UserJpaRepository
-): UserRepository {
+) : UserRepository {
 
     override fun save(user: User) {
         val userJpaEntity: UserJpaEntity = user.toJpaEntity()
@@ -19,7 +21,15 @@ class UserJpaAdapter (
     }
 
     override fun getById(id: UUID): User {
-        TODO("Not yet implemented")
+        return userJpaRepository
+            .findById(id)
+            .orElseThrow {
+                throw CustomException(
+                    type = PersistenceExceptionType.RESOURCE_NOT_FOUND,
+                    message = "유저(id: $id)를 찾을 수 없습니다."
+                )
+            }
+            .toDomain()
     }
 
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/common/exception/PersistenceException.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/common/exception/PersistenceException.kt
@@ -1,0 +1,7 @@
+package com.studentcenter.weave.infrastructure.persistence.common.exception
+
+import com.studentcenter.weave.support.common.exception.CustomExceptionType
+
+enum class PersistenceExceptionType(override val code: String): CustomExceptionType {
+    RESOURCE_NOT_FOUND("PERSISTENCE-001"),
+}

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/entity/UserJpaEntity.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/entity/UserJpaEntity.kt
@@ -80,6 +80,7 @@ class UserJpaEntity(
         private set
 
     companion object {
+
         fun User.toJpaEntity(): UserJpaEntity {
             return UserJpaEntity(
                 id = id,
@@ -95,6 +96,22 @@ class UserJpaEntity(
                 updatedAt = updatedAt,
             )
         }
+    }
+
+    fun toDomain(): User {
+        return User(
+            id = id,
+            nickname = nickname,
+            email = email,
+            gender = gender,
+            mbti = mbti,
+            birthYear = birthYear,
+            universityId = universityId,
+            majorId = majorId,
+            avatar = avatar,
+            registeredAt = registeredAt,
+            updatedAt = updatedAt,
+        )
     }
 
 }


### PR DESCRIPTION
각 모듈별로 `{모듈명}Exceptiontype` enum class 정의해 두고, CustomException에 타입으로 전달해주면 좋을것 같아요

에러 명세는 모든 모듈에 있는 ExceptionType 클래스 스캔해서 API로 전달해주는 방식 생각해봤는데 어떤가요?