### PR TITLE
[WEAV-76] refresh token 발급시 redis 저장 연동

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/port/outbound/UserRefreshTokenRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/port/outbound/UserRefreshTokenRepository.kt
@@ -1,0 +1,15 @@
+package com.studentcenter.weave.application.port.outbound
+
+import java.util.*
+
+interface UserRefreshTokenRepository {
+
+    fun save(
+        id: UUID,
+        refreshToken: String,
+        expirationSeconds: Long
+    )
+
+    fun findByUserId(userId: UUID): String?
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/port/outbound/UserRefreshTokenRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/port/outbound/UserRefreshTokenRepository.kt
@@ -5,7 +5,7 @@ import java.util.*
 interface UserRefreshTokenRepository {
 
     fun save(
-        id: UUID,
+        userId: UUID,
         refreshToken: String,
         expirationSeconds: Long
     )

--- a/application/src/main/kotlin/com/studentcenter/weave/application/service/util/impl/UserTokenServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/service/util/impl/UserTokenServiceImpl.kt
@@ -118,7 +118,7 @@ class UserTokenServiceImpl(
             .createToken(jwtClaims, jwtTokenProperties.refresh.secret)
             .also {
                 userRefreshTokenRepository.save(
-                    id = user.id,
+                    userId = user.id,
                     refreshToken = it,
                     expirationSeconds = jwtTokenProperties.refresh.expireSeconds
                 )

--- a/application/src/test/kotlin/com/studentcenter/weave/application/service/application/UserRegisterApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/service/application/UserRegisterApplicationServiceTest.kt
@@ -4,6 +4,7 @@ import com.studentcenter.weave.application.common.properties.JwtTokenProperties
 import com.studentcenter.weave.application.common.properties.JwtTokenPropertiesFixtureFactory
 import com.studentcenter.weave.application.port.inbound.UserRegisterUseCase
 import com.studentcenter.weave.application.port.outbound.UserAuthInfoRepositorySpy
+import com.studentcenter.weave.application.port.outbound.UserRefreshTokenRepositorySpy
 import com.studentcenter.weave.application.port.outbound.UserRepositorySpy
 import com.studentcenter.weave.application.service.domain.impl.UserAuthInfoDomainServiceImpl
 import com.studentcenter.weave.application.service.domain.impl.UserDomainServiceImpl
@@ -26,7 +27,8 @@ class UserRegisterApplicationServiceTest : DescribeSpec({
     val sut = UserRegisterApplicationService(
         userTokenService = UserTokenServiceImpl(
             jwtTokenProperties = jwtTokenProperties,
-            openIdTokenResolveStrategyFactory = OpenIdTokenResolveStrategyFactoryStub()
+            userRefreshTokenRepository = UserRefreshTokenRepositorySpy(),
+            openIdTokenResolveStrategyFactory = OpenIdTokenResolveStrategyFactoryStub(),
         ),
         userDomainService = UserDomainServiceImpl(userRepositorySpy),
         userAuthInfoDomainService = UserAuthInfoDomainServiceImpl(userAuthInfoRepositorySpy)

--- a/application/src/test/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/service/application/UserSocialLoginApplicationServiceTest.kt
@@ -3,6 +3,7 @@ package com.studentcenter.weave.application.service.application
 import com.studentcenter.weave.application.common.properties.JwtTokenPropertiesFixtureFactory
 import com.studentcenter.weave.application.port.inbound.UserSocialLoginUseCase
 import com.studentcenter.weave.application.port.outbound.UserAuthInfoRepositorySpy
+import com.studentcenter.weave.application.port.outbound.UserRefreshTokenRepositorySpy
 import com.studentcenter.weave.application.port.outbound.UserRepositorySpy
 import com.studentcenter.weave.application.service.domain.impl.UserAuthInfoDomainServiceImpl
 import com.studentcenter.weave.application.service.domain.impl.UserDomainServiceImpl
@@ -23,6 +24,7 @@ class UserSocialLoginApplicationServiceTest : DescribeSpec({
     val sut = UserSocialLoginApplicationService(
         userTokenService = UserTokenServiceImpl(
             jwtTokenProperties = JwtTokenPropertiesFixtureFactory.create(),
+            userRefreshTokenRepository = UserRefreshTokenRepositorySpy(),
             openIdTokenResolveStrategyFactory = OpenIdTokenResolveStrategyFactoryStub(),
         ),
         userDomainService = UserDomainServiceImpl(userRepositorySpy),

--- a/application/src/test/kotlin/com/studentcenter/weave/application/service/util/impl/UserTokenServiceImplTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/service/util/impl/UserTokenServiceImplTest.kt
@@ -1,6 +1,7 @@
 package com.studentcenter.weave.application.service.util.impl
 
 import com.studentcenter.weave.application.common.properties.JwtTokenPropertiesFixtureFactory
+import com.studentcenter.weave.application.port.outbound.UserRefreshTokenRepositorySpy
 import com.studentcenter.weave.application.service.util.impl.strategy.OpenIdTokenResolveStrategyFactoryStub
 import com.studentcenter.weave.application.vo.UserTokenClaims
 import com.studentcenter.weave.domain.entity.User
@@ -18,6 +19,7 @@ class UserTokenServiceImplTest : DescribeSpec({
 
     val sut = UserTokenServiceImpl(
         jwtTokenProperties = JwtTokenPropertiesFixtureFactory.create(),
+        userRefreshTokenRepository = UserRefreshTokenRepositorySpy(),
         openIdTokenResolveStrategyFactory = OpenIdTokenResolveStrategyFactoryStub()
     )
 

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/port/outbound/UserRefreshTokenRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/port/outbound/UserRefreshTokenRepositorySpy.kt
@@ -1,0 +1,22 @@
+package com.studentcenter.weave.application.port.outbound
+
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+class UserRefreshTokenRepositorySpy: UserRefreshTokenRepository {
+
+    private val bucket = ConcurrentHashMap<UUID, String>()
+
+    override fun save(
+        id: UUID,
+        refreshToken: String,
+        expirationSeconds: Long
+    ) {
+        bucket[id] = refreshToken
+    }
+
+    override fun findByUserId(userId: UUID): String? {
+        return bucket[userId]
+    }
+
+}

--- a/bootstrap/http/build.gradle.kts
+++ b/bootstrap/http/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
     implementation(project(":application"))
     implementation(project(":infrastructure:client"))
     implementation(project(":infrastructure:persistence"))
+    implementation(project(":infrastructure:redis"))
 
     implementation("org.springframework.boot:spring-boot-starter-web:${Version.SPRING_BOOT}")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${Version.SPRINGDOC_OPENAPI}")

--- a/bootstrap/http/compose-dev.yaml
+++ b/bootstrap/http/compose-dev.yaml
@@ -19,3 +19,7 @@ services:
       MYSQL_ROOT_PASSWORD: secret
     ports:
       - "3306:3306"
+  redis:
+    image: redis:7.2.4
+    ports:
+      - "6379:6379"

--- a/bootstrap/http/compose-local.yaml
+++ b/bootstrap/http/compose-local.yaml
@@ -7,3 +7,7 @@ services:
       MYSQL_ROOT_PASSWORD: secret
     ports:
       - "3306:3306"
+  redis:
+    image: redis:7.2.4
+    ports:
+      - "6379:6379"

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/WeaveHttpApplication.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/WeaveHttpApplication.kt
@@ -2,6 +2,7 @@ package com.studentcenter.weave.bootstrap
 
 import com.studentcenter.weave.application.common.config.ApplicationConfig
 import com.studentcenter.weave.infrastructure.persistence.common.config.PersistenceConfig
+import com.studentcenter.weave.infrastructure.redis.common.config.RedisConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Import
@@ -9,6 +10,7 @@ import org.springframework.context.annotation.Import
 @SpringBootApplication
 @Import(
     value = [
+        RedisConfig::class,
         PersistenceConfig::class,
         ApplicationConfig::class,
     ]

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/UserRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/UserRestController.kt
@@ -5,6 +5,7 @@ import com.studentcenter.weave.application.vo.UserTokenClaims
 import com.studentcenter.weave.bootstrap.adapter.api.UserApi
 import com.studentcenter.weave.bootstrap.adapter.dto.RegisterUserRequest
 import com.studentcenter.weave.bootstrap.adapter.dto.RegisterUserResponse
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
 
@@ -34,7 +35,7 @@ class UserRestController(
                     accessToken = result.accessToken,
                     refreshToken = result.refreshToken,
                 )
-                ResponseEntity.ok(body)
+                ResponseEntity.status(HttpStatus.CREATED).body(body)
             }
         }
     }

--- a/infrastructure/redis/build.gradle.kts
+++ b/infrastructure/redis/build.gradle.kts
@@ -1,0 +1,14 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+val jar: Jar by tasks
+val bootJar: BootJar by tasks
+
+bootJar.enabled = false
+jar.enabled = true
+
+dependencies {
+    implementation(project(":support:common"))
+    implementation(project(":domain"))
+    implementation(project(":application"))
+    implementation("org.springframework.boot:spring-boot-starter-data-redis:${Version.SPRING_BOOT}")
+}

--- a/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/adapter/UserRefreshTokenRedisAdapter.kt
+++ b/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/adapter/UserRefreshTokenRedisAdapter.kt
@@ -1,0 +1,35 @@
+package com.studentcenter.weave.infrastructure.redis.adapter
+
+import com.studentcenter.weave.application.port.outbound.UserRefreshTokenRepository
+import com.studentcenter.weave.infrastructure.redis.entity.UserRefreshTokenRedisHash
+import com.studentcenter.weave.infrastructure.redis.repository.UserRefreshTokenRedisRepository
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class UserRefreshTokenRedisAdapter(
+    private val userRefreshTokenRedisRepository: UserRefreshTokenRedisRepository
+) : UserRefreshTokenRepository {
+
+    override fun save(
+        id: UUID,
+        refreshToken: String,
+        expirationSeconds: Long
+    ) {
+        val userRefreshTokenRedisHash = UserRefreshTokenRedisHash(
+            id = id,
+            refreshToken = refreshToken,
+            expirationSeconds = expirationSeconds,
+        )
+        userRefreshTokenRedisRepository.save(userRefreshTokenRedisHash)
+    }
+
+    override fun findByUserId(userId: UUID): String? {
+        return userRefreshTokenRedisRepository
+            .findById(userId)
+            .map { it.refreshToken }
+            .orElse(null)
+    }
+
+
+}

--- a/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/common/config/RedisConfig.kt
+++ b/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/common/config/RedisConfig.kt
@@ -26,5 +26,4 @@ class RedisConfig {
         return template
     }
 
-
 }

--- a/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/common/config/RedisConfig.kt
+++ b/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/common/config/RedisConfig.kt
@@ -1,0 +1,30 @@
+package com.studentcenter.weave.infrastructure.redis.common.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories
+
+
+@Configuration
+@ComponentScan(basePackages = ["com.studentcenter.weave.infrastructure.redis"])
+@EnableRedisRepositories(basePackages = ["com.studentcenter.weave.infrastructure.redis.repository"])
+class RedisConfig {
+
+    @Bean
+    fun connectionFactory(): RedisConnectionFactory {
+        return LettuceConnectionFactory()
+    }
+
+    @Bean
+    fun redisTemplate(redisConnectionFactory: RedisConnectionFactory?): RedisTemplate<*, *> {
+        val template = RedisTemplate<ByteArray, ByteArray>()
+        template.connectionFactory = redisConnectionFactory
+        return template
+    }
+
+
+}

--- a/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/entity/UserRefreshTokenRedisHash.kt
+++ b/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/entity/UserRefreshTokenRedisHash.kt
@@ -1,0 +1,26 @@
+package com.studentcenter.weave.infrastructure.redis.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+import java.util.*
+
+@RedisHash("user_refresh_token")
+class UserRefreshTokenRedisHash(
+    id: UUID,
+    refreshToken: String,
+    expirationSeconds: Long
+) {
+
+    @Id
+    var id: UUID = id
+        private set
+
+    var refreshToken: String = refreshToken
+        private set
+
+    @TimeToLive
+    var expirationSeconds: Long = expirationSeconds
+        private set
+
+}

--- a/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/repository/UserRefreshTokenRedisRepository.kt
+++ b/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/repository/UserRefreshTokenRedisRepository.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.infrastructure.redis.repository
+
+import com.studentcenter.weave.infrastructure.redis.entity.UserRefreshTokenRedisHash
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+interface UserRefreshTokenRedisRepository : CrudRepository<UserRefreshTokenRedisHash, UUID>

--- a/infrastructure/redis/src/main/resources/application-redis.yaml
+++ b/infrastructure/redis/src/main/resources/application-redis.yaml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+---
+spring:
+  config:
+    activate:
+      on-profile: dev

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,9 @@ project(":infrastructure:persistence").projectDir = file("infrastructure/persist
 include(":infrastructure:client")
 project(":infrastructure:client").projectDir = file("infrastructure/client")
 
+include(":infrastructure:redis")
+project(":infrastructure:redis").projectDir = file("infrastructure/redis")
+
 // bootstrap
 include(":bootstrap:http")
 project(":bootstrap:http").projectDir = file("bootstrap/http")


### PR DESCRIPTION
## 구현사항
- Redis 설정
- RefreshToken 발급시 Redis에 저장하는 로직 구현이에요
- 변경 문서가 많지만, 내용은 많지않아요 (의존성 추가때문에 생긴 변경사항이 좀있음)
- 회원가입 요청시 Contorller의 실제 응답이 Swagger 명세랑 다른부분이 있어 수정했어요(상태코드 : ok -> created)

## Notify
- Redis를 docker compose에 추가함에 따라 개발서버의 메모리 swap이 잦아질 가능성이 높아 추적관찰이 필요해요
- Redis의 노드당 권장 메모리는 4g / 저장된 데이터의 2배 공간을 권장
- 현재 스왑공간을 9g로 늘렸어요, 아래는 redis 붙이기전 개발서버 메모리 사용현황

```
               total        used        free      shared  buff/cache   available
Mem:           949Mi       671Mi        72Mi       0.0Ki       205Mi       123Mi
Swap:            9Gi       188Mi       9.8Gi
```
