### PR TITLE
[WEAV-128] 회원 정보 조회 모의 응답 구성

### DIFF
--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/UserApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/UserApi.kt
@@ -3,15 +3,18 @@ package com.studentcenter.weave.bootstrap.adapter.api
 import com.studentcenter.weave.application.vo.UserTokenClaims
 import com.studentcenter.weave.bootstrap.adapter.dto.RegisterUserRequest
 import com.studentcenter.weave.bootstrap.adapter.dto.RegisterUserResponse
+import com.studentcenter.weave.bootstrap.adapter.dto.UserGetMyProfileResponse
 import com.studentcenter.weave.bootstrap.common.security.annotation.RegisterTokenClaim
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.Parameters
 import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -42,5 +45,11 @@ interface UserApi {
         @RequestBody
         request: RegisterUserRequest
     ): ResponseEntity<RegisterUserResponse>
+
+    @Operation(summary = "User My Page")
+    @SecurityRequirement(name = "Bearer")
+    @GetMapping("/my-profile")
+    @ResponseStatus(HttpStatus.OK)
+    fun getMyProfile(): UserGetMyProfileResponse
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/UserApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/UserApi.kt
@@ -47,7 +47,7 @@ interface UserApi {
     ): ResponseEntity<RegisterUserResponse>
 
     @Operation(summary = "User My Page")
-    @SecurityRequirement(name = "Bearer")
+    @SecurityRequirement(name = "AccessToken")
     @GetMapping("/my-profile")
     @ResponseStatus(HttpStatus.OK)
     fun getMyProfile(): UserGetMyProfileResponse

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/UserRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/UserRestController.kt
@@ -61,5 +61,4 @@ class UserRestController(
         )
     }
 
-
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/UserRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/controller/UserRestController.kt
@@ -5,6 +5,13 @@ import com.studentcenter.weave.application.vo.UserTokenClaims
 import com.studentcenter.weave.bootstrap.adapter.api.UserApi
 import com.studentcenter.weave.bootstrap.adapter.dto.RegisterUserRequest
 import com.studentcenter.weave.bootstrap.adapter.dto.RegisterUserResponse
+import com.studentcenter.weave.bootstrap.adapter.dto.UserGetMyProfileResponse
+import com.studentcenter.weave.domain.vo.BirthYear
+import com.studentcenter.weave.domain.vo.MajorName
+import com.studentcenter.weave.domain.vo.Mbti
+import com.studentcenter.weave.domain.vo.Nickname
+import com.studentcenter.weave.support.common.uuid.UuidCreator
+import com.studentcenter.weave.support.common.vo.Url
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
@@ -39,5 +46,20 @@ class UserRestController(
             }
         }
     }
+
+    override fun getMyProfile(): UserGetMyProfileResponse {
+        return UserGetMyProfileResponse(
+            id = UuidCreator.create(),
+            nickname = Nickname("test"),
+            birthYear = BirthYear(1999),
+            majorName = MajorName("컴퓨터 공학과"),
+            avatar = Url("https://test.com"),
+            mbti = Mbti("INFP"),
+            animalType = null,
+            height = null,
+            isUniversityEmailVerified = false,
+        )
+    }
+
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/UserGetMyProfileResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/UserGetMyProfileResponse.kt
@@ -1,0 +1,33 @@
+package com.studentcenter.weave.bootstrap.adapter.dto
+
+import com.studentcenter.weave.domain.enum.AnimalType
+import com.studentcenter.weave.domain.vo.BirthYear
+import com.studentcenter.weave.domain.vo.Height
+import com.studentcenter.weave.domain.vo.MajorName
+import com.studentcenter.weave.domain.vo.Mbti
+import com.studentcenter.weave.domain.vo.Nickname
+import com.studentcenter.weave.support.common.vo.Url
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "유저 마이페이지 응답")
+data class UserGetMyProfileResponse (
+    @Schema(description = "유저 아이디")
+    val id: UUID,
+    @Schema(description = "닉네임")
+    val nickname: Nickname,
+    @Schema(description = "생년")
+    val birthYear: BirthYear,
+    @Schema(description = "전공명")
+    val majorName: MajorName,
+    @Schema(description = "프로필 이미지")
+    val avatar: Url?,
+    @Schema(description = "MBTI")
+    val mbti: Mbti,
+    @Schema(description = "닮은 동물")
+    val animalType: AnimalType?,
+    @Schema(description = "키")
+    val height: Height?,
+    @Schema(description = "대학교 이메일 인증 여부")
+    val isUniversityEmailVerified: Boolean,
+)

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/OpenApiConfig.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/OpenApiConfig.kt
@@ -25,4 +25,5 @@ class OpenApiConfig {
                 .bearerFormat("JWT")
         )
     }
+
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/OpenApiConfig.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/OpenApiConfig.kt
@@ -18,7 +18,7 @@ class OpenApiConfig {
     private fun securityComponents(): Components {
         return Components()
             .addSecuritySchemes(
-            "Bearer",
+            "AccessToken",
             SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/OpenApiConfig.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/OpenApiConfig.kt
@@ -1,0 +1,30 @@
+package com.studentcenter.weave.bootstrap.common.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+
+    @Bean
+    fun openApi(): OpenAPI {
+        return OpenAPI()
+            .components(securityComponents())
+    }
+
+    private fun securityComponents(): Components {
+        return Components()
+            .addSecuritySchemes(
+            "Bearer",
+            SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        )
+    }
+
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/OpenApiConfig.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/OpenApiConfig.kt
@@ -25,6 +25,4 @@ class OpenApiConfig {
                 .bearerFormat("JWT")
         )
     }
-
-
 }


### PR DESCRIPTION
- AccessToken이 필요한 API를 설계할때에는 @SecurityRequirement(name = "AccessToken")를 통해 swagger에 명세할 수 있어요
<img width="1474" alt="image" src="https://github.com/Student-Center/weave-server/assets/28651727/aff47cbb-680c-48ef-ab57-3990c6b1d5f1">

Swagger 우측 상단에 Authorize가 나타납니다.

<img width="848" alt="image" src="https://github.com/Student-Center/weave-server/assets/28651727/18c4fbef-210c-4dca-b1f3-2c4ff1b9e201">

access token 집어넣으면 되요

- RefreshToken, RegisterToken의 경우에도 @SecurityRequirement를 적용하고 일관되게 Authorization이라는 헤더키를 사용하게 설계했어야했는데... 이건 추후에 변경하면 좋겠네요