### PR TITLE
[WEAV-128] 회원 정보 모의응답 타입 수정

### DIFF
--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/UserGetMyProfileResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/dto/UserGetMyProfileResponse.kt
@@ -2,16 +2,15 @@ package com.studentcenter.weave.bootstrap.adapter.dto
 
 import com.studentcenter.weave.domain.enum.AnimalType
 import com.studentcenter.weave.domain.vo.BirthYear
-import com.studentcenter.weave.domain.vo.Height
 import com.studentcenter.weave.domain.vo.MajorName
 import com.studentcenter.weave.domain.vo.Mbti
 import com.studentcenter.weave.domain.vo.Nickname
 import com.studentcenter.weave.support.common.vo.Url
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.UUID
+import java.util.*
 
 @Schema(description = "유저 마이페이지 응답")
-data class UserGetMyProfileResponse (
+data class UserGetMyProfileResponse(
     @Schema(description = "유저 아이디")
     val id: UUID,
     @Schema(description = "닉네임")
@@ -27,7 +26,7 @@ data class UserGetMyProfileResponse (
     @Schema(description = "닮은 동물")
     val animalType: AnimalType?,
     @Schema(description = "키")
-    val height: Height?,
+    val height: Int?,
     @Schema(description = "대학교 이메일 인증 여부")
     val isUniversityEmailVerified: Boolean,
 )


### PR DESCRIPTION
<img width="377" alt="image" src="https://github.com/Student-Center/weave-server/assets/28651727/51874201-fdab-452d-8aff-8f03a4b60d54">

height 타입이 어제 말씀드린 value class 이슈때문에 

```
@JvmInline
value class Height(val height: Int) {

    init {
        require(height in 1..300) {
            "키는 1cm 이상 300cm 이하여야 합니다."
        }
    }

}
```

val value로 안쓰고 val height로 정의 되어 있는데요, 
이부분때문에 springdocs-openapi3 라이브러리에서 객체로 인식되나봅니다.

일단 모의응답만 빠르게 Int타입으로 바꿔놓고 고쳐보겠습니다.
