### PR TITLE
[WEAV-137] 인증 필터, 인가 인터셉터 구현

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/common/security/context/UserSecurityContext.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/common/security/context/UserSecurityContext.kt
@@ -1,0 +1,18 @@
+package com.studentcenter.weave.application.common.security.context
+
+import com.studentcenter.weave.application.common.security.vo.UserAuthentication
+import com.studentcenter.weave.support.security.context.SecurityContext
+
+class UserSecurityContext(
+    private var authentication: UserAuthentication,
+) : SecurityContext<UserAuthentication> {
+
+    override fun getAuthentication(): UserAuthentication {
+        return authentication
+    }
+
+    override fun setAuthentication(authentication: UserAuthentication) {
+        this.authentication = authentication
+    }
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/common/security/vo/UserAuthentication.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/common/security/vo/UserAuthentication.kt
@@ -1,0 +1,29 @@
+package com.studentcenter.weave.application.common.security.vo
+
+import com.studentcenter.weave.application.vo.UserTokenClaims
+import com.studentcenter.weave.domain.vo.Nickname
+import com.studentcenter.weave.support.common.vo.Email
+import com.studentcenter.weave.support.common.vo.Url
+import com.studentcenter.weave.support.security.authority.Authentication
+import java.util.*
+
+data class UserAuthentication(
+    val userId: UUID,
+    val nickname: Nickname,
+    val email: Email,
+    val avatar: Url?,
+) : Authentication {
+
+    companion object {
+
+        fun from(claims: UserTokenClaims.AccessToken): UserAuthentication {
+            return UserAuthentication(
+                userId = claims.userId,
+                nickname = claims.nickname,
+                email = claims.email,
+                avatar = claims.avatar
+            )
+        }
+    }
+
+}

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/vo/UserTokenClaimsFixtureFactory.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/vo/UserTokenClaimsFixtureFactory.kt
@@ -1,0 +1,19 @@
+package com.studentcenter.weave.application.vo
+
+import com.studentcenter.weave.domain.entity.User
+import com.studentcenter.weave.domain.entity.UserFixtureFactory
+
+object UserTokenClaimsFixtureFactory {
+
+    fun createAccessTokenClaim(
+        user: User = UserFixtureFactory.create()
+    ): UserTokenClaims.AccessToken {
+        return UserTokenClaims.AccessToken(
+            userId = user.id,
+            email = user.email,
+            nickname = user.nickname,
+            avatar = user.avatar
+        )
+    }
+
+}

--- a/bootstrap/http/build.gradle.kts
+++ b/bootstrap/http/build.gradle.kts
@@ -1,5 +1,7 @@
 dependencies {
     implementation(project(":support:common"))
+    implementation(project(":support:security"))
+
     implementation(project(":domain"))
     implementation(project(":application"))
     implementation(project(":infrastructure:client"))

--- a/bootstrap/http/build.gradle.kts
+++ b/bootstrap/http/build.gradle.kts
@@ -13,4 +13,6 @@ dependencies {
 
     developmentOnly("org.springframework.boot:spring-boot-devtools:${Version.SPRING_BOOT}")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose:${Version.SPRING_BOOT}")
+
+    testImplementation(testFixtures(project(":application")))
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/WebMvcConfig.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/WebMvcConfig.kt
@@ -1,17 +1,26 @@
 package com.studentcenter.weave.bootstrap.common.config
 
+import com.studentcenter.weave.bootstrap.common.security.interceptor.AuthorizationInterceptor
 import com.studentcenter.weave.bootstrap.common.security.resolver.RegisterTokenArgumentResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class WebMvcConfig(
-    private val registerTokenArgumentResolver: RegisterTokenArgumentResolver
+    private val registerTokenArgumentResolver: RegisterTokenArgumentResolver,
+    private val authorizationInterceptor: AuthorizationInterceptor
 ) : WebMvcConfigurer {
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
         resolvers.add(registerTokenArgumentResolver)
         super.addArgumentResolvers(resolvers)
     }
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(authorizationInterceptor)
+        super.addInterceptors(registry)
+    }
+
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/WebMvcConfig.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/config/WebMvcConfig.kt
@@ -10,7 +10,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 @Configuration
 class WebMvcConfig(
     private val registerTokenArgumentResolver: RegisterTokenArgumentResolver,
-    private val authorizationInterceptor: AuthorizationInterceptor
+    private val authorizationInterceptor: AuthorizationInterceptor,
 ) : WebMvcConfigurer {
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/ApiExceptionType.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/ApiExceptionType.kt
@@ -5,4 +5,5 @@ import com.studentcenter.weave.support.common.exception.CustomExceptionType
 enum class ApiExceptionType(override val code: String) : CustomExceptionType {
     INVALID_DATE_EXCEPTION("API-001"),
     INVALID_PARAMETER("API-002"),
+    UNAUTHORIZED("API-003"),
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/ApiExceptionType.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/ApiExceptionType.kt
@@ -5,5 +5,5 @@ import com.studentcenter.weave.support.common.exception.CustomExceptionType
 enum class ApiExceptionType(override val code: String) : CustomExceptionType {
     INVALID_DATE_EXCEPTION("API-001"),
     INVALID_PARAMETER("API-002"),
-    UNAUTHORIZED("API-003"),
+    UNAUTHORIZED_REQUEST("API-003"),
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/annotation/Secured.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/annotation/Secured.kt
@@ -1,0 +1,8 @@
+package com.studentcenter.weave.bootstrap.common.security.annotation
+
+/**
+ * 인증된 사용자만 접근 가능한 API에 사용하는 어노테이션
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class Secured

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/filter/JwtAuthenticationFilter.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/filter/JwtAuthenticationFilter.kt
@@ -1,0 +1,51 @@
+package com.studentcenter.weave.bootstrap.common.security.filter
+
+import com.studentcenter.weave.application.common.security.context.UserSecurityContext
+import com.studentcenter.weave.application.common.security.vo.UserAuthentication
+import com.studentcenter.weave.application.service.util.UserTokenService
+import com.studentcenter.weave.support.security.context.SecurityContextHolder
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(
+    private val userTokenService: UserTokenService,
+) : OncePerRequestFilter() {
+
+    companion object {
+
+        const val TOKEN_HEADER = "Authorization"
+        const val TOKEN_PREFIX = "Bearer "
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        extractToken(request)?.let { processToken(it) }
+        filterChain.doFilter(request, response)
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun extractToken(request: HttpServletRequest): String? {
+        val bearerToken: String? = request.getHeader(TOKEN_HEADER)
+        return if (bearerToken != null && bearerToken.startsWith(TOKEN_PREFIX)) {
+            bearerToken.substring(TOKEN_PREFIX.length)
+        } else null
+    }
+
+    private fun processToken(token: String) {
+        with(userTokenService.resolveAccessToken(token)) {
+            UserAuthentication.from(this)
+        }.let { userAuthentication ->
+            UserSecurityContext(userAuthentication)
+        }.also { securityContext ->
+            SecurityContextHolder.setContext(securityContext)
+        }
+    }
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/filter/JwtAuthenticationFilter.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/filter/JwtAuthenticationFilter.kt
@@ -15,12 +15,6 @@ class JwtAuthenticationFilter(
     private val userTokenService: UserTokenService,
 ) : OncePerRequestFilter() {
 
-    companion object {
-
-        const val TOKEN_HEADER = "Authorization"
-        const val TOKEN_PREFIX = "Bearer "
-    }
-
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -46,6 +40,11 @@ class JwtAuthenticationFilter(
         }.also { securityContext ->
             SecurityContextHolder.setContext(securityContext)
         }
+    }
+
+    companion object {
+        const val TOKEN_HEADER = "Authorization"
+        const val TOKEN_PREFIX = "Bearer "
     }
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptor.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptor.kt
@@ -1,0 +1,46 @@
+package com.studentcenter.weave.bootstrap.common.security.interceptor
+
+import com.studentcenter.weave.application.common.security.vo.UserAuthentication
+import com.studentcenter.weave.bootstrap.common.exception.ApiExceptionType
+import com.studentcenter.weave.support.common.exception.CustomException
+import com.studentcenter.weave.bootstrap.common.security.annotation.Secured
+import com.studentcenter.weave.support.security.context.SecurityContextHolder
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class AuthorizationInterceptor : HandlerInterceptor {
+
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any
+    ): Boolean {
+        if (hasSecuredAnnotation(handler) && isNotAuthenticated()) {
+            throw CustomException(ApiExceptionType.UNAUTHORIZED, "요청 권한이 없습니다.")
+        }
+
+        return super.preHandle(request, response, handler)
+    }
+
+    private fun hasSecuredAnnotation(handler: Any): Boolean {
+        (handler as HandlerMethod).method.declaredAnnotations.forEach {
+            if (it is Secured) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun isNotAuthenticated(): Boolean {
+        SecurityContextHolder
+            .getContext<UserAuthentication>()
+            .let { userAuthentication ->
+                return userAuthentication == null
+            }
+    }
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptor.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptor.kt
@@ -20,7 +20,7 @@ class AuthorizationInterceptor : HandlerInterceptor {
         handler: Any
     ): Boolean {
         if (hasSecuredAnnotation(handler) && isNotAuthenticated()) {
-            throw CustomException(ApiExceptionType.UNAUTHORIZED, "요청 권한이 없습니다.")
+            throw CustomException(ApiExceptionType.UNAUTHORIZED_REQUEST, "요청 권한이 없습니다.")
         }
 
         return super.preHandle(request, response, handler)

--- a/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/common/security/filter/JwtAuthenticationFilterTest.kt
+++ b/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/common/security/filter/JwtAuthenticationFilterTest.kt
@@ -1,0 +1,53 @@
+package com.studentcenter.weave.bootstrap.common.security.filter
+
+import com.studentcenter.weave.application.service.util.UserTokenService
+import com.studentcenter.weave.application.vo.UserTokenClaimsFixtureFactory
+import com.studentcenter.weave.bootstrap.controller.JwtAuthenticationFilterTestController
+import io.kotest.core.spec.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+
+
+@DisplayName("JwtAuthenticationFilterTest")
+@WebMvcTest(JwtAuthenticationFilterTestController::class)
+class JwtAuthenticationFilterTest : DescribeSpec({
+
+    val userTokenService: UserTokenService = mockk<UserTokenService>()
+    val sut = JwtAuthenticationFilter(userTokenService)
+    val mockMvc: MockMvc = MockMvcBuilders
+        .standaloneSetup(JwtAuthenticationFilterTestController())
+        .addFilter<StandaloneMockMvcBuilder?>(sut)
+        .build()
+
+    describe("JwtAuthenticationFilter") {
+        context("Authorization Header에 access toeken을 전달하면") {
+            it("UserAuthentication이 SecurityContextHolder에 저장된다") {
+                // arrange
+                every { userTokenService.resolveAccessToken(any()) } returns UserTokenClaimsFixtureFactory.createAccessTokenClaim()
+
+                // act, assert
+                mockMvc.get("/jwt-authentication-filter-test") {
+                    header("Authorization", "Bearer access-token")
+                }.andExpect {
+                    status { isOk() }
+                }
+            }
+        }
+
+        context("Authorization Header에 access toeken을 전달하지 않으면") {
+            it("UserAuthentication이 SecurityContextHolder에 저장되지 않는다") {
+                // act, assert
+                mockMvc.get("/jwt-authentication-filter-test").andExpect {
+                    status { isUnauthorized() }
+                }
+            }
+        }
+    }
+
+})

--- a/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptorTest.kt
+++ b/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptorTest.kt
@@ -1,0 +1,86 @@
+package com.studentcenter.weave.bootstrap.common.security.interceptor
+
+import com.studentcenter.weave.application.service.util.UserTokenService
+import com.studentcenter.weave.application.vo.UserTokenClaimsFixtureFactory
+import com.studentcenter.weave.bootstrap.common.exception.CustomExceptionHandler
+import com.studentcenter.weave.bootstrap.common.security.filter.JwtAuthenticationFilter
+import com.studentcenter.weave.bootstrap.controller.AuthorizationInterceptorTestController
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.test.web.servlet.setup.StandaloneMockMvcBuilder
+
+@DisplayName("AuthorizationInterceptorTest")
+@WebMvcTest(
+    AuthorizationInterceptorTestController::class,
+    CustomExceptionHandler::class
+)
+class AuthorizationInterceptorTest : DescribeSpec({
+
+    val userTokenService: UserTokenService = mockk<UserTokenService>()
+    val authenticationFilter = JwtAuthenticationFilter(userTokenService)
+    val sut = AuthorizationInterceptor()
+    val mockMvc: MockMvc = MockMvcBuilders
+        .standaloneSetup(AuthorizationInterceptorTestController())
+        .setControllerAdvice(CustomExceptionHandler())
+        .addFilter<StandaloneMockMvcBuilder?>(authenticationFilter)
+        .addInterceptors(sut)
+        .build()
+
+    describe("AuthorizationInterceptor") {
+        context("유효한 인증 토큰과 함께, @Secured 어노테이션이 붙은 메소드에 접근하면") {
+            it("정상적으로 요청이 처리 된다") {
+                // arrange
+                every { userTokenService.resolveAccessToken(any()) } returns UserTokenClaimsFixtureFactory.createAccessTokenClaim()
+
+                // act, assert
+                mockMvc.get("/secured-method") {
+                    header("Authorization", "Bearer access-token")
+                }.andExpect {
+                    status { isOk() }
+                }
+            }
+        }
+
+        context("인증 토큰 없이, @Secured 어노테이션이 붙은 메소드에 접근하면") {
+            it("API-003(Unauthorized)을 응답한다") {
+                // act, assert
+                mockMvc.get("/secured-method").andExpect {
+                    status { isBadRequest() }
+                    content {
+                        jsonPath("$.exceptionCode") { value("API-003") }
+                    }
+                }
+            }
+        }
+
+        context("유효한 인증 토큰과 함께, @Secured 어노테이션이 없는 메소드에 접근하면") {
+            it("정상적으로 요청이 처리 된다") {
+                // arrange
+                every { userTokenService.resolveAccessToken(any()) } returns UserTokenClaimsFixtureFactory.createAccessTokenClaim()
+
+                // act, assert
+                mockMvc.get("/unsecured-method") {
+                    header("Authorization", "Bearer access-token")
+                }.andExpect {
+                    status { isOk() }
+                }
+            }
+        }
+
+        context("인증 토큰 없이, @Secured 어노테이션이 없는 메소드에 접근하면") {
+            it("정상적으로 요청이 처리 된다") {
+                // act, assert
+                mockMvc.get("/unsecured-method").andExpect {
+                    status { isOk() }
+                }
+            }
+        }
+    }
+
+})

--- a/bootstrap/http/src/testFixtures/kotlin/com/studentcenter/weave/bootstrap/controller/AuthorizationInterceptorTestController.kt
+++ b/bootstrap/http/src/testFixtures/kotlin/com/studentcenter/weave/bootstrap/controller/AuthorizationInterceptorTestController.kt
@@ -1,0 +1,25 @@
+package com.studentcenter.weave.bootstrap.controller
+
+import com.studentcenter.weave.bootstrap.common.security.annotation.Secured
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AuthorizationInterceptorTestController {
+
+    @Secured
+    @GetMapping("/secured-method")
+    @ResponseStatus(HttpStatus.OK)
+    fun securedMethod() {
+        /* secured method */
+    }
+
+    @GetMapping("/unsecured-method")
+    @ResponseStatus(HttpStatus.OK)
+    fun unsecuredMethod() {
+        /* unsecured method */
+    }
+
+}

--- a/bootstrap/http/src/testFixtures/kotlin/com/studentcenter/weave/bootstrap/controller/JwtAuthenticationFilterTestController.kt
+++ b/bootstrap/http/src/testFixtures/kotlin/com/studentcenter/weave/bootstrap/controller/JwtAuthenticationFilterTestController.kt
@@ -1,0 +1,25 @@
+package com.studentcenter.weave.bootstrap.controller
+
+import com.studentcenter.weave.application.common.security.vo.UserAuthentication
+import com.studentcenter.weave.support.security.context.SecurityContextHolder
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class JwtAuthenticationFilterTestController {
+
+    @GetMapping("/jwt-authentication-filter-test")
+    fun jwtAuthenticationFilterTest(): ResponseEntity<Unit> {
+        val userAuthentication: UserAuthentication? = SecurityContextHolder
+            .getContext<UserAuthentication>()
+            ?.getAuthentication()
+
+        if (userAuthentication != null) {
+            return ResponseEntity.ok().build()
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+    }
+
+}

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/annotation/Secured.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/annotation/Secured.kt
@@ -1,5 +1,0 @@
-package com.studentcenter.weave.support.security.annotation
-
-@Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FUNCTION)
-annotation class Secured

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/annotation/Secured.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/annotation/Secured.kt
@@ -1,0 +1,5 @@
+package com.studentcenter.weave.support.security.annotation
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class Secured

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/authority/Authentication.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/authority/Authentication.kt
@@ -1,0 +1,3 @@
+package com.studentcenter.weave.support.security.authority
+
+interface Authentication

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/context/SecurityContext.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/context/SecurityContext.kt
@@ -1,0 +1,11 @@
+package com.studentcenter.weave.support.security.context
+
+import com.studentcenter.weave.support.security.authority.Authentication
+
+interface SecurityContext {
+
+    fun getAuthentication(): Authentication?
+
+    fun setAuthentication(authentication: Authentication)
+
+}

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/context/SecurityContext.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/context/SecurityContext.kt
@@ -2,10 +2,10 @@ package com.studentcenter.weave.support.security.context
 
 import com.studentcenter.weave.support.security.authority.Authentication
 
-interface SecurityContext {
+interface SecurityContext<T: Authentication> {
 
-    fun getAuthentication(): Authentication?
+    fun getAuthentication(): T
 
-    fun setAuthentication(authentication: Authentication)
+    fun setAuthentication(authentication: T)
 
 }

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/context/SecurityContextHolder.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/context/SecurityContextHolder.kt
@@ -1,14 +1,17 @@
 package com.studentcenter.weave.support.security.context
 
+import com.studentcenter.weave.support.security.authority.Authentication
+
 object SecurityContextHolder {
 
-    private val contextHolder = ThreadLocal<SecurityContext>()
+    private val contextHolder = ThreadLocal<SecurityContext<*>>()
 
-    fun getContext(): SecurityContext {
-        return contextHolder.get()
+    @Suppress("UNCHECKED_CAST")
+    fun <T : Authentication> getContext(): SecurityContext<T>? {
+        return contextHolder.get() as SecurityContext<T>?
     }
 
-    fun setContext(context: SecurityContext) {
+    fun <T : Authentication> setContext(context: SecurityContext<T>) {
         contextHolder.set(context)
     }
 

--- a/support/security/src/main/kotlin/com/studentcenter/weave/support/security/context/SecurityContextHolder.kt
+++ b/support/security/src/main/kotlin/com/studentcenter/weave/support/security/context/SecurityContextHolder.kt
@@ -1,0 +1,19 @@
+package com.studentcenter.weave.support.security.context
+
+object SecurityContextHolder {
+
+    private val contextHolder = ThreadLocal<SecurityContext>()
+
+    fun getContext(): SecurityContext {
+        return contextHolder.get()
+    }
+
+    fun setContext(context: SecurityContext) {
+        contextHolder.set(context)
+    }
+
+    fun clearContext() {
+        contextHolder.remove()
+    }
+
+}


### PR DESCRIPTION
## 구현사항
- :support:security 모듈
  - SecurityContextHolder 구현 
    - 스레드 로컬로 필터에서 인증된 사용자 인증정보를 요청내에서 전역적으로 접근가능하게 만들어둠)
  - JwtAuthenticationFilter 
    - 토큰이 있으면 파싱해 ContextHolder에 인증 정보 저장, 
    - 요청 완료 이후 context clear -> thread 재사용으로 인해 사용자 정보가 다른 요청에 공유되지 않도록 구현
  - AuthorizationFilter
    - `@Secured` 어노테이션이 붙은 핸들러는 필터를 통해 SecurityContextHolder에 저장된 사용자 정보가 있어야만 접근 가능
    - 해당 정보가 없을 경우 HTTP 400 - exceptionCode=API-003 (unauthorized) 응답

## 논의 사항
- 예외코드들은 400으로 통일하되, exceptionCode로 구분하는것이 좋을것 같아요
- Spring Security 는 러닝커브가 있기도 하고 너무 불필요하게 많은 기능을 제공하는것 같아서 배제시켰어요