### PR TITLE
[WEAV-137] Secured 어노테이션 적용 (로그아웃, 사용자 프로필 API)

### DIFF
--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/AuthApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/AuthApi.kt
@@ -4,13 +4,13 @@ import com.studentcenter.weave.bootstrap.adapter.dto.RefreshLoginTokenResponse
 import com.studentcenter.weave.bootstrap.adapter.dto.RefreshTokenRequest
 import com.studentcenter.weave.bootstrap.adapter.dto.SocialLoginRequest
 import com.studentcenter.weave.bootstrap.adapter.dto.SocialLoginResponse
+import com.studentcenter.weave.bootstrap.common.security.annotation.Secured
 import com.studentcenter.weave.domain.enum.SocialLoginProvider
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -67,9 +67,9 @@ interface AuthApi {
     ): RefreshLoginTokenResponse
 
 
+    @Secured
     @Operation(summary = "Logout")
     @PostMapping("/logout")
-    @SecurityRequirement(name = "AccessToken")
     @ResponseStatus(HttpStatus.OK)
     fun logout()
 

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/UserApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/adapter/api/UserApi.kt
@@ -5,12 +5,12 @@ import com.studentcenter.weave.bootstrap.adapter.dto.RegisterUserRequest
 import com.studentcenter.weave.bootstrap.adapter.dto.RegisterUserResponse
 import com.studentcenter.weave.bootstrap.adapter.dto.UserGetMyProfileResponse
 import com.studentcenter.weave.bootstrap.common.security.annotation.RegisterTokenClaim
+import com.studentcenter.weave.bootstrap.common.security.annotation.Secured
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.Parameters
 import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -46,8 +46,8 @@ interface UserApi {
         request: RegisterUserRequest
     ): ResponseEntity<RegisterUserResponse>
 
+    @Secured
     @Operation(summary = "User My Page")
-    @SecurityRequirement(name = "AccessToken")
     @GetMapping("/my-profile")
     @ResponseStatus(HttpStatus.OK)
     fun getMyProfile(): UserGetMyProfileResponse

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/annotation/Secured.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/annotation/Secured.kt
@@ -1,8 +1,11 @@
 package com.studentcenter.weave.bootstrap.common.security.annotation
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+
 /**
  * 인증된 사용자만 접근 가능한 API에 사용하는 어노테이션
  */
+@SecurityRequirement(name = "AccessToken")
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class Secured

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptor.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptor.kt
@@ -24,19 +24,14 @@ class AuthorizationInterceptor : HandlerInterceptor {
         }
 
         if (hasSecuredAnnotation(handler) && isNotAuthenticated()) {
-            throw CustomException(ApiExceptionType.UNAUTHORIZED_REQUEST, "요청 권한이 없습니다.")
+            throw CustomException(ApiExceptionType.UNAUTHORIZED_REQUEST, UNAUTHORIZED_REQUEST_MESSAGE)
         }
 
         return super.preHandle(request, response, handler)
     }
 
     private fun hasSecuredAnnotation(handler: Any): Boolean {
-        (handler as HandlerMethod).method.declaredAnnotations.forEach {
-            if (it is Secured) {
-                return true
-            }
-        }
-        return false
+        return (handler as HandlerMethod).hasMethodAnnotation(Secured::class.java)
     }
 
     private fun isNotAuthenticated(): Boolean {
@@ -45,6 +40,10 @@ class AuthorizationInterceptor : HandlerInterceptor {
             .let { userAuthentication ->
                 return userAuthentication == null
             }
+    }
+
+    companion object {
+        const val UNAUTHORIZED_REQUEST_MESSAGE = "요청 권한이 없습니다."
     }
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptor.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptor.kt
@@ -43,7 +43,7 @@ class AuthorizationInterceptor : HandlerInterceptor {
     }
 
     companion object {
-        const val UNAUTHORIZED_REQUEST_MESSAGE = "요청 권한이 없습니다."
+        const val UNAUTHORIZED_REQUEST_MESSAGE = "인증되지 않은 사용자 입니다."
     }
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptor.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/security/interceptor/AuthorizationInterceptor.kt
@@ -19,6 +19,10 @@ class AuthorizationInterceptor : HandlerInterceptor {
         response: HttpServletResponse,
         handler: Any
     ): Boolean {
+        if (handler !is HandlerMethod) {
+            return super.preHandle(request, response, handler)
+        }
+
         if (hasSecuredAnnotation(handler) && isNotAuthenticated()) {
             throw CustomException(ApiExceptionType.UNAUTHORIZED_REQUEST, "요청 권한이 없습니다.")
         }


### PR DESCRIPTION
## 구현사항 
- 로그아웃, 사용자 프로필 API에 Secured 어노테이션을 적용했어요
- 인터셉터에 핸들러 메서드 여부를 체크하는 로직이 없어 Swagger동작에 오류가 있었어요, 핸들러 메서드 여부 확인하도록 변경했어요 (정적 리소스 요청시에는 핸들러 메서드가 아니기에 분기 필요)
- 적용 방법에 대해 [문서화](https://www.notion.so/student-center/API-7e5c043eeac64ddb9b10439d49aff693)했어요
