### PR TITLE
[WEAV-132] 애플 소셜 로그인 API 구현

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategy.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategy.kt
@@ -33,13 +33,7 @@ class AppleOpenIdTokenResolveStrategy(
     private fun extractNicknameFromEmail(email: String): String {
         val nickname: String = email.substringBefore(emailDelimiter)
 
-        return adjustNickname(nickname)
-    }
-
-    private fun adjustNickname(nickname: String): String {
-        return if (nickname.length > Nickname.MAX_LENGTH) nickname.substring(
-            0,
-            Nickname.MAX_LENGTH
-        ) else nickname
+        return if (nickname.length <= Nickname.MAX_LENGTH) nickname
+            else nickname.substring(0, Nickname.MAX_LENGTH)
     }
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategy.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategy.kt
@@ -15,9 +15,7 @@ class AppleOpenIdTokenResolveStrategy(
     private val openIdProperties: OpenIdProperties
 ) : OpenIdTokenResolveStrategy {
 
-    companion object {
-        const val DEFAULT_NICKNAME = ""
-    }
+    val emailDelimiter: String = "@"
 
     override fun resolveIdToken(idToken: String): UserTokenClaims.IdToken {
         val jwksUri =
@@ -27,8 +25,21 @@ class AppleOpenIdTokenResolveStrategy(
         val email = result.customClaims["email"] as String
 
         return UserTokenClaims.IdToken(
-            nickname = Nickname(DEFAULT_NICKNAME),
+            nickname = Nickname(extractNicknameFromEmail(email)),
             email = Email(email),
         )
+    }
+
+    private fun extractNicknameFromEmail(email: String): String {
+        val nickname: String = email.substringBefore(emailDelimiter)
+
+        return adjustNickname(nickname)
+    }
+
+    private fun adjustNickname(nickname: String): String {
+        return if (nickname.length > Nickname.MAX_LENGTH) nickname.substring(
+            0,
+            Nickname.MAX_LENGTH
+        ) else nickname
     }
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategy.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategy.kt
@@ -1,13 +1,34 @@
 package com.studentcenter.weave.application.user.service.util.impl.strategy
 
+import com.studentcenter.weave.application.common.properties.OpenIdProperties
 import com.studentcenter.weave.application.user.vo.UserTokenClaims
+import com.studentcenter.weave.domain.user.enums.SocialLoginProvider
+import com.studentcenter.weave.domain.user.vo.Nickname
+import com.studentcenter.weave.support.common.vo.Email
+import com.studentcenter.weave.support.security.jwt.util.JwtTokenProvider
+import com.studentcenter.weave.support.security.jwt.vo.JwtClaims
 import org.springframework.stereotype.Component
+import java.net.URL
 
 @Component
-class AppleOpenIdTokenResolveStrategy : OpenIdTokenResolveStrategy {
+class AppleOpenIdTokenResolveStrategy(
+    private val openIdProperties: OpenIdProperties
+) : OpenIdTokenResolveStrategy {
 
-    override fun resolveIdToken(idToken: String): UserTokenClaims.IdToken {
-        TODO("Not yet implemented")
+    companion object {
+        const val DEFAULT_NICKNAME = ""
     }
 
+    override fun resolveIdToken(idToken: String): UserTokenClaims.IdToken {
+        val jwksUri =
+            URL(this.openIdProperties.providers.getValue(SocialLoginProvider.APPLE).jwksUri)
+        val result: JwtClaims = JwtTokenProvider.verifyJwksBasedToken(idToken, jwksUri).getOrThrow()
+
+        val email = result.customClaims["email"] as String
+
+        return UserTokenClaims.IdToken(
+            nickname = Nickname(DEFAULT_NICKNAME),
+            email = Email(email),
+        )
+    }
 }

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserSocialLoginApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserSocialLoginApplicationServiceTest.kt
@@ -13,9 +13,11 @@ import com.studentcenter.weave.domain.user.entity.UserAuthInfoFixtureFactory
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
 import com.studentcenter.weave.domain.user.enums.SocialLoginProvider
 import io.kotest.assertions.asClue
+import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.types.shouldBeTypeOf
 
+@DisplayName("UserSocialLoginApplicationService")
 class UserSocialLoginApplicationServiceTest : DescribeSpec({
 
     val userRepositorySpy = UserRepositorySpy()

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategyTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategyTest.kt
@@ -3,18 +3,15 @@ package com.studentcenter.weave.application.user.service.util.impl.strategy
 import com.studentcenter.weave.application.common.properties.OpenIdPropertiesFixtureFactory
 import com.studentcenter.weave.support.security.jwt.util.JwtTokenProvider
 import com.studentcenter.weave.support.security.jwt.vo.JwtClaims
-import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkObject
 
-@DisplayName("KakaoOpenIdTokenResolveStrategy")
-class KakaoOpenIdTokenResolveStrategyTest : DescribeSpec({
+class AppleOpenIdTokenResolveStrategyTest : DescribeSpec({
 
-
-    val sut = KakaoOpenIdTokenResolveStrategy(
+    val sut = AppleOpenIdTokenResolveStrategy(
         openIdProperties = OpenIdPropertiesFixtureFactory.create(SOCIAL_LOGIN_PROVIDER_TYPE),
     )
 
@@ -25,7 +22,7 @@ class KakaoOpenIdTokenResolveStrategyTest : DescribeSpec({
         } returns runCatching {
             JwtClaims {
                 customClaims {
-                    this["nickname"] = "nickname"
+                    this["nickname"] = ""
                     this["email"] = "test@test.com"
                 }
             }
@@ -45,7 +42,7 @@ class KakaoOpenIdTokenResolveStrategyTest : DescribeSpec({
             val result = sut.resolveIdToken(idToken)
 
             // assert
-            result.nickname.value shouldBe "nickname"
+            result.nickname.value shouldBe ""
             result.email.value shouldBe "test@test.com"
         }
     }
@@ -54,8 +51,6 @@ class KakaoOpenIdTokenResolveStrategyTest : DescribeSpec({
 
 {
     companion object {
-        const val SOCIAL_LOGIN_PROVIDER_TYPE = "KAKAO"
+        const val SOCIAL_LOGIN_PROVIDER_TYPE = "APPLE"
     }
 }
-
-

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategyTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategyTest.kt
@@ -46,7 +46,6 @@ class AppleOpenIdTokenResolveStrategyTest : DescribeSpec({
             val result = sut.resolveIdToken(idToken)
 
             // assert
-            result.nickname.value shouldBe "test"
             result.email.value shouldBe "test@test.com"
         }
     }

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategyTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/AppleOpenIdTokenResolveStrategyTest.kt
@@ -1,18 +1,23 @@
 package com.studentcenter.weave.application.user.service.util.impl.strategy
 
 import com.studentcenter.weave.application.common.properties.OpenIdPropertiesFixtureFactory
+import com.studentcenter.weave.domain.user.enums.SocialLoginProvider
 import com.studentcenter.weave.support.security.jwt.util.JwtTokenProvider
 import com.studentcenter.weave.support.security.jwt.vo.JwtClaims
+import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockkObject
 
+@DisplayName("AppleOpenIdTokenResolveStrategy")
 class AppleOpenIdTokenResolveStrategyTest : DescribeSpec({
 
+    val socialLoginProvider: SocialLoginProvider = SocialLoginProvider.APPLE
+
     val sut = AppleOpenIdTokenResolveStrategy(
-        openIdProperties = OpenIdPropertiesFixtureFactory.create(SOCIAL_LOGIN_PROVIDER_TYPE),
+        openIdProperties = OpenIdPropertiesFixtureFactory.create(socialLoginProvider),
     )
 
     beforeTest {
@@ -22,7 +27,6 @@ class AppleOpenIdTokenResolveStrategyTest : DescribeSpec({
         } returns runCatching {
             JwtClaims {
                 customClaims {
-                    this["nickname"] = ""
                     this["email"] = "test@test.com"
                 }
             }
@@ -42,15 +46,9 @@ class AppleOpenIdTokenResolveStrategyTest : DescribeSpec({
             val result = sut.resolveIdToken(idToken)
 
             // assert
-            result.nickname.value shouldBe ""
+            result.nickname.value shouldBe "test"
             result.email.value shouldBe "test@test.com"
         }
     }
 
 })
-
-{
-    companion object {
-        const val SOCIAL_LOGIN_PROVIDER_TYPE = "APPLE"
-    }
-}

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/KakaoOpenIdTokenResolveStrategyTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/util/impl/strategy/KakaoOpenIdTokenResolveStrategyTest.kt
@@ -1,6 +1,7 @@
 package com.studentcenter.weave.application.user.service.util.impl.strategy
 
 import com.studentcenter.weave.application.common.properties.OpenIdPropertiesFixtureFactory
+import com.studentcenter.weave.domain.user.enums.SocialLoginProvider
 import com.studentcenter.weave.support.security.jwt.util.JwtTokenProvider
 import com.studentcenter.weave.support.security.jwt.vo.JwtClaims
 import io.kotest.core.annotation.DisplayName
@@ -13,9 +14,10 @@ import io.mockk.mockkObject
 @DisplayName("KakaoOpenIdTokenResolveStrategy")
 class KakaoOpenIdTokenResolveStrategyTest : DescribeSpec({
 
+    val socialLoginProvider: SocialLoginProvider = SocialLoginProvider.KAKAO
 
     val sut = KakaoOpenIdTokenResolveStrategy(
-        openIdProperties = OpenIdPropertiesFixtureFactory.create(SOCIAL_LOGIN_PROVIDER_TYPE),
+        openIdProperties = OpenIdPropertiesFixtureFactory.create(socialLoginProvider),
     )
 
     beforeTest {
@@ -51,11 +53,3 @@ class KakaoOpenIdTokenResolveStrategyTest : DescribeSpec({
     }
 
 })
-
-{
-    companion object {
-        const val SOCIAL_LOGIN_PROVIDER_TYPE = "KAKAO"
-    }
-}
-
-

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/common/properties/OpenIdPropertiesFixtureFactory.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/common/properties/OpenIdPropertiesFixtureFactory.kt
@@ -6,8 +6,9 @@ class OpenIdPropertiesFixtureFactory {
 
     companion object {
         fun create(
+            providerType : String,
             providers: Map<SocialLoginProvider, OpenIdProperties.Properties> = mapOf(
-                SocialLoginProvider.KAKAO to createProperties(),
+                SocialLoginProvider.valueOf(providerType) to createProperties(),
             ),
         ): OpenIdProperties {
             return OpenIdProperties(

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/common/properties/OpenIdPropertiesFixtureFactory.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/common/properties/OpenIdPropertiesFixtureFactory.kt
@@ -6,9 +6,9 @@ class OpenIdPropertiesFixtureFactory {
 
     companion object {
         fun create(
-            providerType : String,
+            socialLoginProvider: SocialLoginProvider,
             providers: Map<SocialLoginProvider, OpenIdProperties.Properties> = mapOf(
-                SocialLoginProvider.valueOf(providerType) to createProperties(),
+                socialLoginProvider to createProperties(),
             ),
         ): OpenIdProperties {
             return OpenIdProperties(

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/user/vo/Nickname.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/user/vo/Nickname.kt
@@ -7,10 +7,11 @@ value class Nickname(
 
     companion object {
 
+        const val MIN_LENGTH = 1
         const val MAX_LENGTH = 10
     }
 
     init {
-        require(value.length <= MAX_LENGTH) { "닉네임은 ${MAX_LENGTH}자 이하여야 합니다." }
+        require(value.length in MIN_LENGTH..MAX_LENGTH) { "닉네임은 ${MIN_LENGTH}글자 이상 ${MAX_LENGTH}자 이하여야 합니다." }
     }
 }

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/user/vo/Nickname.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/user/vo/Nickname.kt
@@ -8,11 +8,9 @@ value class Nickname(
     companion object {
 
         const val MAX_LENGTH = 10
-        const val MIN_LENGTH = 1
     }
 
     init {
-        require(value.length in MIN_LENGTH..MAX_LENGTH) { "닉네임은 ${MIN_LENGTH}글자 이상 ${MAX_LENGTH}자 이하여야 합니다." }
+        require(value.length <= MAX_LENGTH) { "닉네임은 ${MAX_LENGTH}자 이하여야 합니다." }
     }
-
 }

--- a/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/NicknameTest.kt
+++ b/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/NicknameTest.kt
@@ -1,24 +1,26 @@
 package com.studentcenter.weave.domain.user.vo
 
-import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class NicknameTest : FunSpec ({
 
-    test("닉네임이 존재하는 경우, 최대 길이는 10자 이하여야 합니다.") {
+    test("최대 글자수 기준보다 긴 닉네임을 생성하는 경우, 에러가 발생한다.") {
 
         val exception = shouldThrow<IllegalArgumentException> {
             Nickname("닉".repeat(11))
         }
 
-        exception.message shouldBe "닉네임은 ${Nickname.MAX_LENGTH}자 이하여야 합니다."
+        exception.message shouldBe "닉네임은 ${Nickname.MIN_LENGTH}글자 이상 ${Nickname.MAX_LENGTH}자 이하여야 합니다."
     }
 
-    test("닉네임 생성 시 빈 문자열을 사용하는 경우, 정상적으로 생성된다.") {
-        shouldNotThrow<IllegalArgumentException> {
+    test("최소 글자수 기준보다 짧은 길이의 닉네임을 생성하는 경우, 에러가 발생한다.") {
+
+        val exception = shouldThrow<IllegalArgumentException> {
             Nickname("")
         }
+
+        exception.message shouldBe "닉네임은 ${Nickname.MIN_LENGTH}글자 이상 ${Nickname.MAX_LENGTH}자 이하여야 합니다."
     }
 })

--- a/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/NicknameTest.kt
+++ b/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/NicknameTest.kt
@@ -10,19 +10,15 @@ class NicknameTest : FunSpec ({
 
     test("최대 글자수 기준(10) 보다 긴 닉네임을 생성하는 경우, 에러가 발생한다.") {
 
-        val exception = shouldThrow<IllegalArgumentException> {
-            Nickname("닉".repeat(11))
+        shouldThrow<IllegalArgumentException> {
+            Nickname("닉".repeat(Nickname.MAX_LENGTH + 1))
         }
-
-        exception.message shouldBe "닉네임은 ${Nickname.MIN_LENGTH}글자 이상 ${Nickname.MAX_LENGTH}자 이하여야 합니다."
     }
 
     test("최소 글자수 기준(1) 보다 짧은 길이의 닉네임을 생성하는 경우, 에러가 발생한다.") {
 
-        val exception = shouldThrow<IllegalArgumentException> {
+        shouldThrow<IllegalArgumentException> {
             Nickname("")
         }
-
-        exception.message shouldBe "닉네임은 ${Nickname.MIN_LENGTH}글자 이상 ${Nickname.MAX_LENGTH}자 이하여야 합니다."
     }
 })

--- a/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/NicknameTest.kt
+++ b/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/NicknameTest.kt
@@ -1,0 +1,24 @@
+package com.studentcenter.weave.domain.user.vo
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class NicknameTest : FunSpec ({
+
+    test("닉네임이 존재하는 경우, 최대 길이는 10자 이하여야 합니다.") {
+
+        val exception = shouldThrow<IllegalArgumentException> {
+            Nickname("닉".repeat(11))
+        }
+
+        exception.message shouldBe "닉네임은 ${Nickname.MAX_LENGTH}자 이하여야 합니다."
+    }
+
+    test("닉네임 생성 시 빈 문자열을 사용하는 경우, 정상적으로 생성된다.") {
+        shouldNotThrow<IllegalArgumentException> {
+            Nickname("")
+        }
+    }
+})

--- a/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/NicknameTest.kt
+++ b/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/NicknameTest.kt
@@ -1,12 +1,14 @@
 package com.studentcenter.weave.domain.user.vo
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
+@DisplayName("NicknameTest")
 class NicknameTest : FunSpec ({
 
-    test("최대 글자수 기준보다 긴 닉네임을 생성하는 경우, 에러가 발생한다.") {
+    test("최대 글자수 기준(10) 보다 긴 닉네임을 생성하는 경우, 에러가 발생한다.") {
 
         val exception = shouldThrow<IllegalArgumentException> {
             Nickname("닉".repeat(11))
@@ -15,7 +17,7 @@ class NicknameTest : FunSpec ({
         exception.message shouldBe "닉네임은 ${Nickname.MIN_LENGTH}글자 이상 ${Nickname.MAX_LENGTH}자 이하여야 합니다."
     }
 
-    test("최소 글자수 기준보다 짧은 길이의 닉네임을 생성하는 경우, 에러가 발생한다.") {
+    test("최소 글자수 기준(1) 보다 짧은 길이의 닉네임을 생성하는 경우, 에러가 발생한다.") {
 
         val exception = shouldThrow<IllegalArgumentException> {
             Nickname("")


### PR DESCRIPTION
### Summary
애플 소셜 로그인 API 구현 완료했습니다. 

문서 숙지가 오래 걸렸고 코드는 전반적으로 산님이 구조 잡아두셔서 거즘 변경사항 없이 할 수 있었네요 😊😊

* Nickname의 경우에는 idTokenResolve해서 반환할 때, 빈 문자열 `""` 태워서 반환하는 방식으로 우선 적용했습니다!

### 요구사항 명세서
https://www.notion.so/student-center/API-6423f88b21b941da86acf5e79b99c93f