### PR TITLE
[WEAV-187] 내 미팅팀 조회 응답 API 모의 응답 구현

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/MeetingTeamGetMyUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/MeetingTeamGetMyUseCase.kt
@@ -1,0 +1,22 @@
+package com.studentcenter.weave.application.meeting.port.inbound
+
+import com.studentcenter.weave.application.meeting.vo.MeetingTeamInfo
+import com.studentcenter.weave.support.common.dto.ScrollRequest
+import com.studentcenter.weave.support.common.dto.ScrollResponse
+import java.util.UUID
+
+interface MeetingTeamGetMyUseCase {
+
+    fun invoke(scrollRequest: ScrollRequest): Result
+
+    data class Result(
+        override val item: List<MeetingTeamInfo>,
+        override val lastItemId: UUID?,
+        override val limit: Int,
+    ) : ScrollResponse<MeetingTeamInfo>(
+        item = item,
+        lastItemId = lastItemId,
+        limit = limit,
+    )
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamGetMyApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamGetMyApplicationService.kt
@@ -1,0 +1,70 @@
+package com.studentcenter.weave.application.meeting.service.application
+
+import com.studentcenter.weave.application.meeting.port.inbound.MeetingTeamGetMyUseCase
+import com.studentcenter.weave.application.meeting.vo.MeetingTeamInfo
+import com.studentcenter.weave.domain.meeting.entity.MeetingTeam
+import com.studentcenter.weave.domain.meeting.enums.Location
+import com.studentcenter.weave.domain.meeting.vo.TeamIntroduce
+import com.studentcenter.weave.domain.university.entity.University
+import com.studentcenter.weave.domain.university.vo.UniversityName
+import com.studentcenter.weave.domain.user.entity.User
+import com.studentcenter.weave.domain.user.enums.Gender
+import com.studentcenter.weave.domain.user.vo.BirthYear
+import com.studentcenter.weave.domain.user.vo.Mbti
+import com.studentcenter.weave.domain.user.vo.Nickname
+import com.studentcenter.weave.support.common.dto.ScrollRequest
+import com.studentcenter.weave.support.common.uuid.UuidCreator
+import com.studentcenter.weave.support.common.vo.Email
+import org.springframework.stereotype.Service
+
+@Service
+class MeetingTeamGetMyApplicationService : MeetingTeamGetMyUseCase {
+
+    override fun invoke(scrollRequest: ScrollRequest): MeetingTeamGetMyUseCase.Result {
+
+        // TODO: Implement the logic
+
+        val user = User.create(
+            nickname = Nickname("nickname"),
+            mbti = Mbti("Intj"),
+            email = Email("test@test.com"),
+            gender = Gender.MAN,
+            birthYear = BirthYear(1995),
+            universityId = UuidCreator.create(),
+            majorId = UuidCreator.create(),
+            avatar = null,
+        )
+
+        val university = University.create(
+            name = UniversityName("test"),
+            domainAddress = "test",
+            logoAddress = "test"
+        )
+
+        val memberInfo = MeetingTeamInfo.MemberInfo.of(
+            user = user,
+            university = university,
+            isLeader = true,
+            isMe = true,
+        )
+
+        val meetingTeam = MeetingTeam.create(
+            teamIntroduce = TeamIntroduce("test"),
+            leaderUser = user,
+            memberCount = 4,
+            location = Location.SUWON,
+        )
+
+        val meetingTeamInfo = MeetingTeamInfo.of(
+            team = meetingTeam,
+            memberInfos = listOf(memberInfo),
+        )
+
+        return MeetingTeamGetMyUseCase.Result(
+            item = listOf(meetingTeamInfo),
+            lastItemId = null,
+            limit = scrollRequest.limit,
+        )
+    }
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/vo/MeetingTeamInfo.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/vo/MeetingTeamInfo.kt
@@ -1,0 +1,53 @@
+package com.studentcenter.weave.application.meeting.vo
+
+import com.studentcenter.weave.domain.meeting.entity.MeetingTeam
+import com.studentcenter.weave.domain.university.entity.University
+import com.studentcenter.weave.domain.user.entity.User
+
+data class MeetingTeamInfo(
+    val team: MeetingTeam,
+    val memberInfos: List<MemberInfo>
+) {
+
+    companion object {
+
+        fun of(
+            team: MeetingTeam,
+            memberInfos: List<MemberInfo>,
+        ): MeetingTeamInfo {
+            return MeetingTeamInfo(
+                team = team,
+                memberInfos = memberInfos,
+            )
+        }
+
+    }
+
+    data class MemberInfo(
+        val user: User,
+        val university: University,
+        val isLeader: Boolean,
+        val isMe: Boolean,
+    ) {
+
+        companion object {
+
+            fun of(
+                user: User,
+                university: University,
+                isLeader: Boolean,
+                isMe: Boolean,
+            ): MemberInfo {
+                return MemberInfo(
+                    user = user,
+                    university = university,
+                    isLeader = isLeader,
+                    isMe = isMe,
+                )
+            }
+
+        }
+
+    }
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/api/MeetingTeamApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/api/MeetingTeamApi.kt
@@ -2,9 +2,12 @@ package com.studentcenter.weave.bootstrap.meeting.api
 
 import com.studentcenter.weave.bootstrap.common.security.annotation.Secured
 import com.studentcenter.weave.bootstrap.meeting.dto.MeetingTeamCreateRequest
+import com.studentcenter.weave.bootstrap.meeting.dto.MeetingTeamGetMyResponse
+import com.studentcenter.weave.support.common.dto.ScrollRequest
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -22,5 +25,13 @@ interface MeetingTeamApi {
         @RequestBody
         request: MeetingTeamCreateRequest
     )
+
+    @Secured
+    @Operation(summary = "Get my meeting teams")
+    @GetMapping("/my")
+    @ResponseStatus(HttpStatus.OK)
+    fun getMyMeetingTeams(
+        scrollRequest: ScrollRequest
+    ): MeetingTeamGetMyResponse
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingTeamRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingTeamRestController.kt
@@ -1,14 +1,18 @@
 package com.studentcenter.weave.bootstrap.meeting.controller
 
 import com.studentcenter.weave.application.meeting.port.inbound.MeetingTeamCreateUseCase
+import com.studentcenter.weave.application.meeting.port.inbound.MeetingTeamGetMyUseCase
 import com.studentcenter.weave.bootstrap.meeting.api.MeetingTeamApi
 import com.studentcenter.weave.bootstrap.meeting.dto.MeetingTeamCreateRequest
+import com.studentcenter.weave.bootstrap.meeting.dto.MeetingTeamGetMyResponse
 import com.studentcenter.weave.domain.meeting.vo.TeamIntroduce
+import com.studentcenter.weave.support.common.dto.ScrollRequest
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class MeetingTeamRestController(
     private val meetingTeamCreateUseCase: MeetingTeamCreateUseCase,
+    private val meetingTeamGetMyUseCase: MeetingTeamGetMyUseCase,
 ) : MeetingTeamApi {
 
     override fun createMeetingTeam(request: MeetingTeamCreateRequest) {
@@ -17,6 +21,20 @@ class MeetingTeamRestController(
             memberCount = request.memberCount,
             location = request.location,
         ).let { meetingTeamCreateUseCase.invoke(it) }
+    }
+
+    override fun getMyMeetingTeams(scrollRequest: ScrollRequest): MeetingTeamGetMyResponse {
+        return meetingTeamGetMyUseCase.invoke(scrollRequest).let {
+            MeetingTeamGetMyResponse(
+                item = it.item.map { meetingTeamInfo ->
+                    MeetingTeamGetMyResponse.MeetingTeamDto.from(
+                        meetingTeamInfo
+                    )
+                },
+                lastItemId = it.lastItemId,
+                limit = it.limit,
+            )
+        }
     }
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/MeetingTeamGetMyResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/MeetingTeamGetMyResponse.kt
@@ -1,32 +1,71 @@
 package com.studentcenter.weave.bootstrap.meeting.dto
 
-import com.studentcenter.weave.domain.meeting.enums.MeetingTeamStatus
-import com.studentcenter.weave.domain.user.enums.Gender
+import com.studentcenter.weave.application.meeting.vo.MeetingTeamInfo
+import com.studentcenter.weave.support.common.dto.ScrollResponse
 import java.util.*
 
 data class MeetingTeamGetMyResponse(
-    val id: UUID,
-    val teamIntroduce: String,
-    val memberCount: Int,
-    val leaderUserInfo: LeaderUserInfo,
-    val memberUserInfos: List<MemberUserInfo>,
-    val location: String,
-    val gender: Gender,
-    val status: MeetingTeamStatus,
+    override val item: List<MeetingTeamDto>,
+    override val lastItemId: UUID?,
+    override val limit: Int,
+) : ScrollResponse<MeetingTeamGetMyResponse.MeetingTeamDto>(
+    item = item,
+    lastItemId = lastItemId,
+    limit = limit,
 ) {
 
-    data class LeaderUserInfo(
+    data class MeetingTeamDto(
         val id: UUID,
-        val universityName: String,
-        val mbti: String,
-        val birthYear: Int,
-    )
+        val teamIntroduce: String,
+        val memberCount: Int,
+        val location: String,
+        val memberInfos: List<MeetingMemberDto>,
+    ) {
 
-    data class MemberUserInfo(
+        companion object {
+
+            fun from(
+                meetingTeamInfo: MeetingTeamInfo,
+            ): MeetingTeamDto {
+                return MeetingTeamDto(
+                    id = meetingTeamInfo.team.id,
+                    teamIntroduce = meetingTeamInfo.team.teamIntroduce.value,
+                    memberCount = meetingTeamInfo.team.memberCount,
+                    location = meetingTeamInfo.team.location.value,
+                    memberInfos = meetingTeamInfo.memberInfos.map { MeetingMemberDto.from(it) },
+                )
+            }
+
+        }
+
+    }
+
+    data class MeetingMemberDto(
         val id: UUID,
         val universityName: String,
         val mbti: String,
         val birthYear: Int,
-    )
+        val isLeader: Boolean,
+        val isMe: Boolean,
+    ) {
+
+        companion object {
+
+            fun from(
+                memberInfo: MeetingTeamInfo.MemberInfo,
+            ): MeetingMemberDto {
+                return MeetingMemberDto(
+                    id = memberInfo.user.id,
+                    universityName = memberInfo.university.name.value,
+                    mbti = memberInfo.user.mbti.value,
+                    birthYear = memberInfo.user.birthYear.value,
+                    isLeader = memberInfo.isLeader,
+                    isMe = memberInfo.isMe,
+                )
+            }
+
+        }
+
+    }
 
 }

--- a/support/common/src/main/kotlin/com/studentcenter/weave/support/common/dto/ScrollRequest.kt
+++ b/support/common/src/main/kotlin/com/studentcenter/weave/support/common/dto/ScrollRequest.kt
@@ -1,0 +1,8 @@
+package com.studentcenter.weave.support.common.dto
+
+import java.util.UUID
+
+data class ScrollRequest (
+    val lastItemId: UUID?,
+    val limit: Int
+)

--- a/support/common/src/main/kotlin/com/studentcenter/weave/support/common/dto/ScrollResponse.kt
+++ b/support/common/src/main/kotlin/com/studentcenter/weave/support/common/dto/ScrollResponse.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.support.common.dto
+
+import java.util.UUID
+
+abstract class ScrollResponse<T>(
+    open val item: List<T>,
+    open val lastItemId: UUID?,
+    open val limit: Int,
+)


### PR DESCRIPTION
## 구현사항
- 내 미팅팀 조회 응답 모의 응답 구현했어요
- ApplicationService에 있는 내용들은 모의 객체들이에요
- no-offset방식의 무한스크롤 공통 요청, 응답을 위해 ScrollRequest, ScrollResponse를 구현했어요
  - Response 의 경우 abstract로 두고 상속해서 구현하도록 만들어 두었어요.
  
## 요구사항 명세서

https://www.notion.so/student-center/API-776fbb2418f540ca81e7c0a06425ece4