### PR TITLE
[WEAV-176] 미팅팀 생성 유스케이스 리팩터링

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingMemberRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingMemberRepository.kt
@@ -1,0 +1,12 @@
+package com.studentcenter.weave.application.meeting.port.outbound
+
+import com.studentcenter.weave.domain.meeting.entity.MeetingMember
+import java.util.*
+
+interface MeetingMemberRepository {
+
+    fun save(meetingMember: MeetingMember)
+
+    fun countByMeetingTeamId(meetingTeamId: UUID): Int
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingMemberRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingMemberRepository.kt
@@ -9,4 +9,9 @@ interface MeetingMemberRepository {
 
     fun countByMeetingTeamId(meetingTeamId: UUID): Int
 
+    fun findByMeetingTeamIdAndUserId(
+        meetingTeamId: UUID,
+        userId: UUID
+    ): MeetingMember?
+
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingTeamRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingTeamRepository.kt
@@ -1,9 +1,12 @@
 package com.studentcenter.weave.application.meeting.port.outbound
 
 import com.studentcenter.weave.domain.meeting.entity.MeetingTeam
+import java.util.*
 
 interface MeetingTeamRepository {
 
     fun save(meetingTeam: MeetingTeam)
+
+    fun getById(id: UUID): MeetingTeam
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamCreateApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamCreateApplicationService.kt
@@ -3,8 +3,10 @@ package com.studentcenter.weave.application.meeting.service.application
 import com.studentcenter.weave.application.common.security.context.getCurrentUserAuthentication
 import com.studentcenter.weave.application.meeting.port.inbound.MeetingTeamCreateUseCase
 import com.studentcenter.weave.application.meeting.service.domain.MeetingTeamDomainService
-import com.studentcenter.weave.application.user.service.domain.UserDomainService
+import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCase
 import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.domain.meeting.entity.MeetingTeam
+import com.studentcenter.weave.domain.meeting.enums.MeetingMemberRole
 import com.studentcenter.weave.domain.user.entity.User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -12,18 +14,24 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class MeetingTeamCreateApplicationService(
     private val meetingTeamDomainService: MeetingTeamDomainService,
-    private val userDomainService: UserDomainService,
+    private val userQueryUseCase: UserQueryUseCase,
 ) : MeetingTeamCreateUseCase {
 
     @Transactional
     override fun invoke(command: MeetingTeamCreateUseCase.Command) {
         val userAuthentication: UserAuthentication = getCurrentUserAuthentication()
-        val user: User = userDomainService.getById(userAuthentication.userId)
-        meetingTeamDomainService.create(
+        val user: User = userQueryUseCase.getById(userAuthentication.userId)
+        val meetingTeam = MeetingTeam.create(
             teamIntroduce = command.teamIntroduce,
             memberCount = command.memberCount,
-            leaderUser = user,
             location = command.location,
+            gender = user.gender,
+        )
+        meetingTeamDomainService.save(meetingTeam)
+        meetingTeamDomainService.addMember(
+            meetingTeam = meetingTeam,
+            user = user,
+            role = MeetingMemberRole.LEADER,
         )
     }
 

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamGetMyApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamGetMyApplicationService.kt
@@ -49,8 +49,8 @@ class MeetingTeamGetMyApplicationService : MeetingTeamGetMyUseCase {
 
         val meetingTeam = MeetingTeam.create(
             teamIntroduce = TeamIntroduce("test"),
-            leaderUser = user,
             memberCount = 4,
+            gender = Gender.MAN,
             location = Location.SUWON,
         )
 

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingTeamDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingTeamDomainService.kt
@@ -1,17 +1,21 @@
 package com.studentcenter.weave.application.meeting.service.domain
 
+import com.studentcenter.weave.domain.meeting.entity.MeetingMember
 import com.studentcenter.weave.domain.meeting.entity.MeetingTeam
-import com.studentcenter.weave.domain.meeting.enums.Location
-import com.studentcenter.weave.domain.meeting.vo.TeamIntroduce
+import com.studentcenter.weave.domain.meeting.enums.MeetingMemberRole
 import com.studentcenter.weave.domain.user.entity.User
+import java.util.*
 
 interface MeetingTeamDomainService {
 
-    fun create(
-        teamIntroduce: TeamIntroduce,
-        memberCount: Int,
-        leaderUser: User,
-        location: Location,
-    ): MeetingTeam
+    fun save(meetingTeam: MeetingTeam)
+
+    fun getById(id: UUID): MeetingTeam
+
+    fun addMember(
+        user: User,
+        meetingTeam: MeetingTeam,
+        role: MeetingMemberRole,
+    ): MeetingMember
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -33,34 +33,25 @@ class MeetingTeamDomainServiceImpl(
     ): MeetingMember {
         // TODO: 동시성 문제 해결
         checkMemberCount(meetingTeam)
-        checkAlreadyMember(meetingTeam, user)
+        val existingMember = meetingMemberRepository.findByMeetingTeamIdAndUserId(
+            meetingTeam.id,
+            user.id
+        )
 
-        return MeetingMember.create(
-            meetingTeamId = meetingTeam.id,
-            userId = user.id,
-            role = role,
-        ).also {
-            meetingMemberRepository.save(it)
+        return existingMember ?: run {
+            MeetingMember.create(
+                meetingTeamId = meetingTeam.id,
+                userId = user.id,
+                role = role,
+            ).also {
+                meetingMemberRepository.save(it)
+            }
         }
     }
 
     private fun checkMemberCount(meetingTeam: MeetingTeam) {
         require(meetingMemberRepository.countByMeetingTeamId(meetingTeam.id) < meetingTeam.memberCount) {
             "팀원의 수가 초과되었습니다"
-        }
-    }
-
-    private fun checkAlreadyMember(
-        meetingTeam: MeetingTeam,
-        user: User
-    ) {
-        require(
-            meetingMemberRepository.findByMeetingTeamIdAndUserId(
-                meetingTeam.id,
-                user.id
-            ) == null
-        ) {
-            "이미 팀원으로 등록되어 있습니다"
         }
     }
 

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -32,9 +32,8 @@ class MeetingTeamDomainServiceImpl(
         role: MeetingMemberRole,
     ): MeetingMember {
         // TODO: 동시성 문제 해결
-        require(meetingMemberRepository.countByMeetingTeamId(meetingTeam.id) < meetingTeam.memberCount) {
-            "팀원의 수가 초과되었습니다"
-        }
+        checkMemberCount(meetingTeam)
+        checkAlreadyMember(meetingTeam, user)
 
         return MeetingMember.create(
             meetingTeamId = meetingTeam.id,
@@ -42,6 +41,26 @@ class MeetingTeamDomainServiceImpl(
             role = role,
         ).also {
             meetingMemberRepository.save(it)
+        }
+    }
+
+    private fun checkMemberCount(meetingTeam: MeetingTeam) {
+        require(meetingMemberRepository.countByMeetingTeamId(meetingTeam.id) < meetingTeam.memberCount) {
+            "팀원의 수가 초과되었습니다"
+        }
+    }
+
+    private fun checkAlreadyMember(
+        meetingTeam: MeetingTeam,
+        user: User
+    ) {
+        require(
+            meetingMemberRepository.findByMeetingTeamIdAndUserId(
+                meetingTeam.id,
+                user.id
+            ) == null
+        ) {
+            "이미 팀원으로 등록되어 있습니다"
         }
     }
 

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -1,30 +1,47 @@
 package com.studentcenter.weave.application.meeting.service.domain.impl
 
+import com.studentcenter.weave.application.meeting.port.outbound.MeetingMemberRepository
 import com.studentcenter.weave.application.meeting.port.outbound.MeetingTeamRepository
 import com.studentcenter.weave.application.meeting.service.domain.MeetingTeamDomainService
+import com.studentcenter.weave.domain.meeting.entity.MeetingMember
 import com.studentcenter.weave.domain.meeting.entity.MeetingTeam
-import com.studentcenter.weave.domain.meeting.enums.Location
-import com.studentcenter.weave.domain.meeting.vo.TeamIntroduce
+import com.studentcenter.weave.domain.meeting.enums.MeetingMemberRole
 import com.studentcenter.weave.domain.user.entity.User
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
 
 @Service
 class MeetingTeamDomainServiceImpl(
     private val meetingTeamRepository: MeetingTeamRepository,
+    private val meetingMemberRepository: MeetingMemberRepository,
 ) : MeetingTeamDomainService {
 
-    override fun create(
-        teamIntroduce: TeamIntroduce,
-        memberCount: Int,
-        leaderUser: User,
-        location: Location
-    ): MeetingTeam {
-        return MeetingTeam.create(
-            teamIntroduce = teamIntroduce,
-            memberCount = memberCount,
-            leaderUser = leaderUser,
-            location = location
-        ).also { meetingTeamRepository.save(it) }
+    override fun save(meetingTeam: MeetingTeam) {
+        meetingTeamRepository.save(meetingTeam)
+    }
+
+    override fun getById(id: UUID): MeetingTeam {
+        return meetingTeamRepository.getById(id)
+    }
+
+    @Transactional
+    override fun addMember(
+        user: User,
+        meetingTeam: MeetingTeam,
+        role: MeetingMemberRole,
+    ): MeetingMember {
+        require(meetingMemberRepository.countByMeetingTeamId(meetingTeam.id) < meetingTeam.memberCount) {
+            "팀원의 수가 초과되었습니다"
+        }
+
+        return MeetingMember.create(
+            meetingTeamId = meetingTeam.id,
+            userId = user.id,
+            role = role,
+        ).also {
+            meetingMemberRepository.save(it)
+        }
     }
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -31,6 +31,7 @@ class MeetingTeamDomainServiceImpl(
         meetingTeam: MeetingTeam,
         role: MeetingMemberRole,
     ): MeetingMember {
+        // TODO: 동시성 문제 해결
         require(meetingMemberRepository.countByMeetingTeamId(meetingTeam.id) < meetingTeam.memberCount) {
             "팀원의 수가 초과되었습니다"
         }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/user/port/inbound/UserQueryUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/user/port/inbound/UserQueryUseCase.kt
@@ -1,0 +1,10 @@
+package com.studentcenter.weave.application.user.port.inbound
+
+import com.studentcenter.weave.domain.user.entity.User
+import java.util.UUID
+
+interface UserQueryUseCase {
+
+    fun getById(id: UUID): User
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/user/service/application/UserQueryApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/user/service/application/UserQueryApplicationService.kt
@@ -1,0 +1,18 @@
+package com.studentcenter.weave.application.user.service.application
+
+import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCase
+import com.studentcenter.weave.application.user.service.domain.UserDomainService
+import com.studentcenter.weave.domain.user.entity.User
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class UserQueryApplicationService(
+    private val userDomainService: UserDomainService,
+): UserQueryUseCase {
+
+    override fun getById(id: UUID): User {
+        return userDomainService.getById(id)
+    }
+
+}

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamCreateApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamCreateApplicationServiceTest.kt
@@ -9,7 +9,6 @@ import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCaseStu
 import com.studentcenter.weave.application.user.port.outbound.UserRepositorySpy
 import com.studentcenter.weave.application.user.vo.UserAuthentication
 import com.studentcenter.weave.domain.meeting.enums.Location
-import com.studentcenter.weave.domain.meeting.enums.MeetingMemberRole
 import com.studentcenter.weave.domain.meeting.vo.TeamIntroduce
 import com.studentcenter.weave.domain.user.entity.User
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
@@ -70,10 +69,12 @@ class MeetingTeamCreateApplicationServiceTest : DescribeSpec({
 
                 // assert
                 val meetingTeam = meetingTeamRepositorySpy.getLast() shouldNotBe null
-                val members = meetingMemberRepositorySpy.getAllMyMeetingTeamId(meetingTeam.id)
-                members.size shouldBe 1
-                members[0].userId shouldBe leaderUserFixture.id
-                members[0].role shouldBe MeetingMemberRole.LEADER
+                val member = meetingMemberRepositorySpy.getByMeetingTeamIdAndUserId(
+                    meetingTeam.id,
+                    leaderUserFixture.id
+                )
+                member.meetingTeamId shouldBe meetingTeam.id
+                member.userId shouldBe leaderUserFixture.id
             }
         }
     }

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
@@ -1,0 +1,115 @@
+package com.studentcenter.weave.application.meeting.service.domain.impl
+
+import com.studentcenter.weave.application.meeting.outbound.MeetingMemberRepositorySpy
+import com.studentcenter.weave.application.meeting.outbound.MeetingTeamRepositorySpy
+import com.studentcenter.weave.domain.meeting.entity.MeetingMember
+import com.studentcenter.weave.domain.meeting.entity.MeetingTeamFixtureFactory
+import com.studentcenter.weave.domain.meeting.enums.MeetingMemberRole
+import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+@DisplayName("MeetingTeamDomainServiceImpl")
+class MeetingTeamDomainServiceImplTest : DescribeSpec({
+
+    val meetingTeamRepositorySpy = MeetingTeamRepositorySpy()
+    val meetingMemberRepositorySpy = MeetingMemberRepositorySpy()
+    val sut = MeetingTeamDomainServiceImpl(
+        meetingTeamRepository = meetingTeamRepositorySpy,
+        meetingMemberRepository = meetingMemberRepositorySpy,
+    )
+
+    afterEach {
+        meetingTeamRepositorySpy.clear()
+        meetingMemberRepositorySpy.clear()
+    }
+
+    describe("addMember") {
+        context("미팅 멤버수가 초과될 경우") {
+            it("팀원의 수가 초과되었다는 예외를 던진다") {
+                // arrange
+                val memberCount = 2
+                val meetingTeam = MeetingTeamFixtureFactory.create(memberCount = memberCount)
+                val user1 = UserFixtureFactory.create()
+                val user2 = UserFixtureFactory.create()
+                val targetUser = UserFixtureFactory.create()
+
+                val meetingTeamMember1 = MeetingMember.create(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user1.id,
+                    role = MeetingMemberRole.LEADER
+                )
+                val meetingTeamMember2 = MeetingMember.create(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user2.id,
+                    role = MeetingMemberRole.MEMBER
+                )
+
+                meetingMemberRepositorySpy.save(meetingTeamMember1)
+                meetingMemberRepositorySpy.save(meetingTeamMember2)
+
+                // act, assert
+                shouldThrow<IllegalArgumentException> {
+                    sut.addMember(
+                        user = targetUser,
+                        meetingTeam = meetingTeam,
+                        role = MeetingMemberRole.MEMBER
+                    )
+                }
+            }
+        }
+
+        context("미팅 멤버수가 초과 되지 않았을 경우") {
+            it("팀원을 추가한다") {
+                // arrange
+                val memberCount = 2
+                val meetingTeam = MeetingTeamFixtureFactory.create(memberCount = memberCount)
+                val user = UserFixtureFactory.create()
+
+                // act
+                sut.addMember(
+                    user = user,
+                    meetingTeam = meetingTeam,
+                    role = MeetingMemberRole.MEMBER
+                )
+
+                // assert
+                val member = meetingMemberRepositorySpy.getByMeetingTeamIdAndUserId(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user.id
+                )
+                member.meetingTeamId shouldBe meetingTeam.id
+                member.userId shouldBe user.id
+            }
+        }
+
+        context("미팅 멤버가 이미 존재하는 경우") {
+            it("이미 존재한다는 예외를 던진다") {
+                // arrange
+                val memberCount = 2
+                val meetingTeam = MeetingTeamFixtureFactory.create(memberCount = memberCount)
+                val user = UserFixtureFactory.create()
+
+                val meetingTeamMember = MeetingMember.create(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user.id,
+                    role = MeetingMemberRole.MEMBER
+                )
+                meetingMemberRepositorySpy.save(meetingTeamMember)
+
+                // act, assert
+                shouldThrow<IllegalArgumentException> {
+                    sut.addMember(
+                        user = user,
+                        meetingTeam = meetingTeam,
+                        role = MeetingMemberRole.MEMBER
+                    )
+                }
+            }
+        }
+
+    }
+
+})

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
@@ -86,30 +86,29 @@ class MeetingTeamDomainServiceImplTest : DescribeSpec({
         }
 
         context("미팅 멤버가 이미 존재하는 경우") {
-            it("이미 존재한다는 예외를 던진다") {
+            it("해당 멤버를 반환한다.") {
                 // arrange
                 val memberCount = 2
                 val meetingTeam = MeetingTeamFixtureFactory.create(memberCount = memberCount)
                 val user = UserFixtureFactory.create()
-
-                val meetingTeamMember = MeetingMember.create(
+                val meetingMember = MeetingMember.create(
                     meetingTeamId = meetingTeam.id,
                     userId = user.id,
                     role = MeetingMemberRole.MEMBER
                 )
-                meetingMemberRepositorySpy.save(meetingTeamMember)
+                meetingMemberRepositorySpy.save(meetingMember)
 
-                // act, assert
-                shouldThrow<IllegalArgumentException> {
-                    sut.addMember(
-                        user = user,
-                        meetingTeam = meetingTeam,
-                        role = MeetingMemberRole.MEMBER
-                    )
-                }
+                // act
+                val result = sut.addMember(
+                    user = user,
+                    meetingTeam = meetingTeam,
+                    role = MeetingMemberRole.MEMBER
+                )
+
+                // assert
+                result shouldBe meetingMember
             }
         }
-
     }
 
 })

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingMemberRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingMemberRepositorySpy.kt
@@ -17,8 +17,19 @@ class MeetingMemberRepositorySpy : MeetingMemberRepository {
         return bucket.values.count { it.meetingTeamId == meetingTeamId }
     }
 
-    fun getAllMyMeetingTeamId(meetingTeamId: UUID): List<MeetingMember> {
-        return bucket.values.filter { it.meetingTeamId == meetingTeamId }
+    override fun findByMeetingTeamIdAndUserId(
+        meetingTeamId: UUID,
+        userId: UUID
+    ): MeetingMember? {
+        return bucket.values.find { it.meetingTeamId == meetingTeamId && it.userId == userId }
+    }
+
+    fun getByMeetingTeamIdAndUserId(
+        meetingTeamId: UUID,
+        userId: UUID
+    ): MeetingMember {
+        return findByMeetingTeamIdAndUserId(meetingTeamId, userId)
+            ?: throw NoSuchElementException("MeetingMember not found")
     }
 
     fun clear() {

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingMemberRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingMemberRepositorySpy.kt
@@ -1,0 +1,28 @@
+package com.studentcenter.weave.application.meeting.outbound
+
+import com.studentcenter.weave.application.meeting.port.outbound.MeetingMemberRepository
+import com.studentcenter.weave.domain.meeting.entity.MeetingMember
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+class MeetingMemberRepositorySpy : MeetingMemberRepository {
+
+    private val bucket = ConcurrentHashMap<UUID, MeetingMember>()
+
+    override fun save(meetingMember: MeetingMember) {
+        bucket[meetingMember.id] = meetingMember
+    }
+
+    override fun countByMeetingTeamId(meetingTeamId: UUID): Int {
+        return bucket.values.count { it.meetingTeamId == meetingTeamId }
+    }
+
+    fun getAllMyMeetingTeamId(meetingTeamId: UUID): List<MeetingMember> {
+        return bucket.values.filter { it.meetingTeamId == meetingTeamId }
+    }
+
+    fun clear() {
+        bucket.clear()
+    }
+
+}

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingTeamRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingTeamRepositorySpy.kt
@@ -13,8 +13,12 @@ class MeetingTeamRepositorySpy: MeetingTeamRepository {
         bucket[meetingTeam.id] = meetingTeam
     }
 
-    fun findByLeaderUserId(leaderUserId: UUID): MeetingTeam? {
-        return bucket.values.find { it.leaderUserId == leaderUserId }
+    override fun getById(id: UUID): MeetingTeam {
+        return bucket[id] ?: throw NoSuchElementException()
+    }
+
+    fun getLast(): MeetingTeam {
+        return bucket.values.last()
     }
 
     fun clear() {

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/user/port/inbound/UserQueryUseCaseStub.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/user/port/inbound/UserQueryUseCaseStub.kt
@@ -1,0 +1,13 @@
+package com.studentcenter.weave.application.user.port.inbound
+
+import com.studentcenter.weave.domain.user.entity.User
+import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import java.util.*
+
+class UserQueryUseCaseStub : UserQueryUseCase {
+
+    override fun getById(id: UUID): User {
+        return UserFixtureFactory.create(id = id)
+    }
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/api/MeetingTeamApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/api/MeetingTeamApi.kt
@@ -31,7 +31,7 @@ interface MeetingTeamApi {
     @GetMapping("/my")
     @ResponseStatus(HttpStatus.OK)
     fun getMyMeetingTeams(
-        scrollRequest: MeetingTeamGetMyRequest
+        request: MeetingTeamGetMyRequest
     ): MeetingTeamGetMyResponse
 
 }

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/entity/MeetingMember.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/entity/MeetingMember.kt
@@ -1,0 +1,29 @@
+package com.studentcenter.weave.domain.meeting.entity
+
+import com.studentcenter.weave.domain.meeting.enums.MeetingMemberRole
+import java.util.*
+
+data class MeetingMember(
+    val id: UUID,
+    val meetingTeamId: UUID,
+    val userId: UUID,
+    val role: MeetingMemberRole,
+) {
+
+    companion object {
+
+        fun create(
+            meetingTeamId: UUID,
+            userId: UUID,
+            role: MeetingMemberRole,
+        ): MeetingMember {
+            return MeetingMember(
+                id = UUID.randomUUID(),
+                meetingTeamId = meetingTeamId,
+                userId = userId,
+                role = role,
+            )
+        }
+    }
+
+}

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/entity/MeetingTeam.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/entity/MeetingTeam.kt
@@ -3,7 +3,6 @@ package com.studentcenter.weave.domain.meeting.entity
 import com.studentcenter.weave.domain.meeting.enums.Location
 import com.studentcenter.weave.domain.meeting.enums.MeetingTeamStatus
 import com.studentcenter.weave.domain.meeting.vo.TeamIntroduce
-import com.studentcenter.weave.domain.user.entity.User
 import com.studentcenter.weave.domain.user.enums.Gender
 import com.studentcenter.weave.support.common.uuid.UuidCreator
 import java.util.*
@@ -11,9 +10,7 @@ import java.util.*
 data class MeetingTeam(
     val id: UUID = UuidCreator.create(),
     val teamIntroduce: TeamIntroduce,
-    val memberUserIds: Set<UUID>,
     val memberCount: Int,
-    val leaderUserId: UUID,
     val location: Location,
     val status: MeetingTeamStatus,
     val gender: Gender,
@@ -29,20 +26,18 @@ data class MeetingTeam(
 
         fun create(
             teamIntroduce: TeamIntroduce,
-            leaderUser: User,
-            memberUserIds: Set<UUID> = emptySet(),
             memberCount: Int,
             location: Location,
+            gender: Gender
         ): MeetingTeam {
             return MeetingTeam(
                 teamIntroduce = teamIntroduce,
-                memberUserIds = memberUserIds,
                 memberCount = memberCount,
-                leaderUserId = leaderUser.id,
                 location = location,
                 status = MeetingTeamStatus.WAITING,
-                gender = leaderUser.gender,
+                gender = gender,
             )
         }
     }
+
 }

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/enums/MeetingMemberRole.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/enums/MeetingMemberRole.kt
@@ -1,0 +1,5 @@
+package com.studentcenter.weave.domain.meeting.enums
+
+enum class MeetingMemberRole {
+    LEADER, MEMBER
+}

--- a/domain/src/test/kotlin/com/studentcenter/weave/domain/meeting/entity/MeetingTeamTest.kt
+++ b/domain/src/test/kotlin/com/studentcenter/weave/domain/meeting/entity/MeetingTeamTest.kt
@@ -4,6 +4,7 @@ import com.studentcenter.weave.domain.meeting.enums.Location
 import com.studentcenter.weave.domain.meeting.enums.MeetingTeamStatus
 import com.studentcenter.weave.domain.meeting.vo.TeamIntroduce
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import com.studentcenter.weave.domain.user.enums.Gender
 import com.studentcenter.weave.support.common.uuid.UuidCreator
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
@@ -13,62 +14,14 @@ import java.util.UUID
 
 class MeetingTeamTest : FunSpec({
 
-    (2..4).forEach() { memberCount ->
-        test("팀원의 수는 최소 2명 최대 4명까지 가능하다 : $memberCount 명 - 성공") {
-            // arrange
-            val teamIntroduce = TeamIntroduce("팀 한줄 소개")
-            val leaderUser = UserFixtureFactory.create()
-            val memberUserIds = setOf(UuidCreator.create(), UuidCreator.create())
-            val location = Location.BUSAN
-
-            // act, assert
-            shouldNotThrowAny {
-                MeetingTeam.create(
-                    teamIntroduce = teamIntroduce,
-                    leaderUser = leaderUser,
-                    memberUserIds = memberUserIds,
-                    memberCount = memberCount,
-                    location = location,
-                )
-            }
-        }
-    }
-
-    listOf(1, 5).forEach() { memberCount ->
-        test("팀원의 수는 최소 2명 최대 4명까지 가능하다 : $memberCount 명 - 실패") {
-            // arrange
-            val teamIntroduce = TeamIntroduce("팀 한줄 소개")
-            val leaderUser = UserFixtureFactory.create()
-            val memberUserIds = setOf(UuidCreator.create(), UuidCreator.create())
-            val location = Location.BUSAN
-
-            // act, assert
-            shouldThrow<IllegalArgumentException> {
-                MeetingTeam.create(
-                    teamIntroduce = teamIntroduce,
-                    leaderUser = leaderUser,
-                    memberUserIds = memberUserIds,
-                    memberCount = memberCount,
-                    location = location,
-                )
-            }
-        }
-    }
 
     test("미팅 팀 생성시 WAITING 상태로 생성된다.") {
-        // arrange
-        val teamIntroduce = TeamIntroduce("팀 한줄 소개")
-        val leaderUser = UserFixtureFactory.create()
-        val memberUserIds = emptySet<UUID>()
-        val location = Location.BUSAN
-
-        // act
+        // arrange, act
         val meetingTeam = MeetingTeam.create(
-            teamIntroduce = teamIntroduce,
-            leaderUser = leaderUser,
-            memberUserIds = memberUserIds,
+            teamIntroduce = TeamIntroduce("팀 한줄 소개"),
             memberCount = 2,
-            location = location,
+            location = Location.BUSAN,
+            gender = Gender.MAN,
         )
 
         // assert

--- a/domain/src/test/kotlin/com/studentcenter/weave/domain/meeting/entity/MeetingTeamTest.kt
+++ b/domain/src/test/kotlin/com/studentcenter/weave/domain/meeting/entity/MeetingTeamTest.kt
@@ -14,6 +14,39 @@ import java.util.UUID
 
 class MeetingTeamTest : FunSpec({
 
+    (2..4).forEach() { memberCount ->
+        test("팀원의 수는 최소 2명 최대 4명까지 가능하다 : $memberCount 명 - 성공") {
+            val teamIntroduce = TeamIntroduce("팀 한줄 소개")
+            val location = Location.BUSAN
+            val gender = Gender.MAN
+
+            shouldNotThrowAny {
+                MeetingTeam.create(
+                    teamIntroduce = teamIntroduce,
+                    memberCount = memberCount,
+                    location = location,
+                    gender = gender,
+                )
+            }
+        }
+    }
+
+    listOf(1, 5).forEach() { memberCount ->
+        test("팀원의 수는 최소 2명 최대 4명까지 가능하다 : $memberCount 명 - 실패") {
+            val teamIntroduce = TeamIntroduce("팀 한줄 소개")
+            val location = Location.BUSAN
+            val gender = Gender.MAN
+
+            shouldThrow<IllegalArgumentException> {
+                MeetingTeam.create(
+                    teamIntroduce = teamIntroduce,
+                    memberCount = memberCount,
+                    location = location,
+                    gender = gender,
+                )
+            }
+        }
+    }
 
     test("미팅 팀 생성시 WAITING 상태로 생성된다.") {
         // arrange, act

--- a/domain/src/testFixtures/kotlin/com/studentcenter/weave/domain/meeting/entity/MeetingTeamFixtureFactory.kt
+++ b/domain/src/testFixtures/kotlin/com/studentcenter/weave/domain/meeting/entity/MeetingTeamFixtureFactory.kt
@@ -1,0 +1,29 @@
+package com.studentcenter.weave.domain.meeting.entity
+
+import com.studentcenter.weave.domain.meeting.enums.Location
+import com.studentcenter.weave.domain.meeting.enums.MeetingTeamStatus
+import com.studentcenter.weave.domain.meeting.vo.TeamIntroduce
+import com.studentcenter.weave.domain.user.enums.Gender
+import com.studentcenter.weave.support.common.uuid.UuidCreator
+import java.util.*
+
+object MeetingTeamFixtureFactory {
+
+    fun create(
+        id: UUID = UuidCreator.create(),
+        memberCount: Int = 4,
+        teamIntroduce: TeamIntroduce = TeamIntroduce("팀 소개"),
+        location: Location = Location.SUWON,
+        status: MeetingTeamStatus = MeetingTeamStatus.WAITING,
+        gender: Gender = Gender.MAN,
+    ): MeetingTeam {
+        return MeetingTeam(
+            id = id,
+            memberCount = memberCount,
+            teamIntroduce = teamIntroduce,
+            location = location,
+            status = status,
+            gender = gender,
+        )
+    }
+}

--- a/domain/src/testFixtures/kotlin/com/studentcenter/weave/domain/user/entity/UserFixtureFactory.kt
+++ b/domain/src/testFixtures/kotlin/com/studentcenter/weave/domain/user/entity/UserFixtureFactory.kt
@@ -14,6 +14,7 @@ import java.util.*
 object UserFixtureFactory {
 
     fun create(
+        id: UUID = UuidCreator.create(),
         nickname: Nickname = Nickname("닉네임"),
         email: Email = Email("test@test.com"),
         gender: Gender = Gender.MAN,
@@ -26,6 +27,7 @@ object UserFixtureFactory {
         animalType: AnimalType? = null,
     ): User {
         return User(
+            id = id,
             nickname = nickname,
             email = email,
             gender = gender,

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingMemberJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingMemberJpaAdapter.kt
@@ -10,7 +10,7 @@ import java.util.*
 @Component
 class MeetingMemberJpaAdapter(
     private val meetingMemberJpaRepository: MeetingMemberJpaRepository,
-): MeetingMemberRepository {
+) : MeetingMemberRepository {
 
     override fun save(meetingMember: MeetingMember) {
         meetingMemberJpaRepository.save(meetingMember.toJpaEntity())
@@ -18,6 +18,14 @@ class MeetingMemberJpaAdapter(
 
     override fun countByMeetingTeamId(meetingTeamId: UUID): Int {
         return meetingMemberJpaRepository.countByMeetingTeamId(meetingTeamId)
+    }
+
+    override fun findByMeetingTeamIdAndUserId(
+        meetingTeamId: UUID,
+        userId: UUID
+    ): MeetingMember? {
+        return meetingMemberJpaRepository.findByMeetingTeamIdAndUserId(meetingTeamId, userId)
+            ?.toDomain()
     }
 
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingMemberJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingMemberJpaAdapter.kt
@@ -1,0 +1,23 @@
+package com.studentcenter.weave.infrastructure.persistence.meeting.adapter
+
+import com.studentcenter.weave.application.meeting.port.outbound.MeetingMemberRepository
+import com.studentcenter.weave.domain.meeting.entity.MeetingMember
+import com.studentcenter.weave.infrastructure.persistence.meeting.entity.MeetingMemberJpaEntity.Companion.toJpaEntity
+import com.studentcenter.weave.infrastructure.persistence.meeting.repository.MeetingMemberJpaRepository
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class MeetingMemberJpaAdapter(
+    private val meetingMemberJpaRepository: MeetingMemberJpaRepository,
+): MeetingMemberRepository {
+
+    override fun save(meetingMember: MeetingMember) {
+        meetingMemberJpaRepository.save(meetingMember.toJpaEntity())
+    }
+
+    override fun countByMeetingTeamId(meetingTeamId: UUID): Int {
+        return meetingMemberJpaRepository.countByMeetingTeamId(meetingTeamId)
+    }
+
+}

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingTeamJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingTeamJpaAdapter.kt
@@ -2,9 +2,12 @@ package com.studentcenter.weave.infrastructure.persistence.meeting.adapter
 
 import com.studentcenter.weave.application.meeting.port.outbound.MeetingTeamRepository
 import com.studentcenter.weave.domain.meeting.entity.MeetingTeam
+import com.studentcenter.weave.infrastructure.persistence.common.exception.PersistenceExceptionType
 import com.studentcenter.weave.infrastructure.persistence.meeting.entity.MeetingTeamJpaEntity.Companion.toJpaEntity
 import com.studentcenter.weave.infrastructure.persistence.meeting.repository.MeetingTeamJpaRepository
+import com.studentcenter.weave.support.common.exception.CustomException
 import org.springframework.stereotype.Component
+import java.util.*
 
 @Component
 class MeetingTeamJpaAdapter(
@@ -15,6 +18,17 @@ class MeetingTeamJpaAdapter(
         meetingTeam
             .toJpaEntity()
             .let { meetingTeamJpaRepository.save(it) }
+    }
+
+    override fun getById(id: UUID): MeetingTeam {
+        return meetingTeamJpaRepository
+            .findById(id)
+            .orElseThrow() {
+                CustomException(
+                    type = PersistenceExceptionType.RESOURCE_NOT_FOUND,
+                    message = "MeetingTeam(id=$id)를 찾을 수 없습니다"
+                )
+            }.toDomain()
     }
 
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/entity/MeetingMemberJpaEntity.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/entity/MeetingMemberJpaEntity.kt
@@ -1,0 +1,59 @@
+package com.studentcenter.weave.infrastructure.persistence.meeting.entity
+
+import com.studentcenter.weave.domain.meeting.entity.MeetingMember
+import com.studentcenter.weave.domain.meeting.enums.MeetingMemberRole
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.*
+
+@Entity
+@Table(name = "meeting_member")
+class MeetingMemberJpaEntity(
+    id: UUID,
+    meetingTeamId: UUID,
+    userId: UUID,
+    role: MeetingMemberRole,
+) {
+
+    @Id
+    var id: UUID = id
+        private set
+
+    @Column(nullable = false)
+    var meetingTeamId = meetingTeamId
+        private set
+
+    @Column(nullable = false)
+    var userId = userId
+        private set
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    var role = role
+        private set
+
+    fun toDomain(): MeetingMember {
+        return MeetingMember(
+            id = id,
+            meetingTeamId = meetingTeamId,
+            userId = userId,
+            role = role,
+        )
+    }
+
+    companion object {
+        fun MeetingMember.toJpaEntity(): MeetingMemberJpaEntity {
+            return MeetingMemberJpaEntity(
+                id = id,
+                meetingTeamId = meetingTeamId,
+                userId = userId,
+                role = role,
+            )
+        }
+    }
+
+}

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/entity/MeetingTeamJpaEntity.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/entity/MeetingTeamJpaEntity.kt
@@ -5,14 +5,11 @@ import com.studentcenter.weave.domain.meeting.enums.Location
 import com.studentcenter.weave.domain.meeting.enums.MeetingTeamStatus
 import com.studentcenter.weave.domain.meeting.vo.TeamIntroduce
 import com.studentcenter.weave.domain.user.enums.Gender
-import jakarta.persistence.CollectionTable
 import jakarta.persistence.Column
-import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
 import jakarta.persistence.Table
 import java.util.*
 
@@ -21,8 +18,6 @@ import java.util.*
 class MeetingTeamJpaEntity(
     id: UUID,
     teamIntroduce: TeamIntroduce,
-    leaderUserId: UUID,
-    memberUserIds: Set<UUID>,
     memberCount: Int,
     location: Location,
     status: MeetingTeamStatus,
@@ -39,17 +34,7 @@ class MeetingTeamJpaEntity(
         private set
 
     @Column(nullable = false)
-    var leaderUserId: UUID = leaderUserId
-        private set
-
-    @Column(nullable = false)
     var memberCount: Int = memberCount
-        private set
-
-    @ElementCollection
-    @CollectionTable(name = "meeting_team_member", joinColumns = [JoinColumn(name = "meeting_team_id")])
-    @Column(name = "user_id")
-    var memberUserIds: Set<UUID> = memberUserIds
         private set
 
     @Enumerated(EnumType.STRING)
@@ -67,19 +52,30 @@ class MeetingTeamJpaEntity(
     var gender: Gender = gender
         private set
 
-    companion object{
+    fun toDomain(): MeetingTeam {
+        return MeetingTeam(
+            id = id,
+            teamIntroduce = teamIntroduce,
+            memberCount = memberCount,
+            location = location,
+            status = status,
+            gender = gender,
+        )
+    }
+
+    companion object {
+
         fun MeetingTeam.toJpaEntity(): MeetingTeamJpaEntity {
             return MeetingTeamJpaEntity(
                 id = id,
                 teamIntroduce = teamIntroduce,
-                leaderUserId = leaderUserId,
-                memberUserIds = memberUserIds,
                 memberCount = memberCount,
                 location = location,
                 status = status,
                 gender = gender,
             )
         }
+
     }
 
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingMemberJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingMemberJpaRepository.kt
@@ -1,0 +1,13 @@
+package com.studentcenter.weave.infrastructure.persistence.meeting.repository
+
+import com.studentcenter.weave.infrastructure.persistence.meeting.entity.MeetingMemberJpaEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+interface MeetingMemberJpaRepository : JpaRepository<MeetingMemberJpaEntity, UUID> {
+
+    fun countByMeetingTeamId(meetingTeamId: UUID): Int
+
+}

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingMemberJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingMemberJpaRepository.kt
@@ -10,4 +10,9 @@ interface MeetingMemberJpaRepository : JpaRepository<MeetingMemberJpaEntity, UUI
 
     fun countByMeetingTeamId(meetingTeamId: UUID): Int
 
+    fun findByMeetingTeamIdAndUserId(
+        meetingTeamId: UUID,
+        userId: UUID
+    ): MeetingMemberJpaEntity?
+
 }

--- a/infrastructure/persistence/src/main/resources/application-persistence.yaml
+++ b/infrastructure/persistence/src/main/resources/application-persistence.yaml
@@ -20,6 +20,9 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: true
+  flyway:
+    clean-disabled: false
+    clean-on-validation-error: true
 ---
 spring:
   config:

--- a/infrastructure/persistence/src/main/resources/application-persistence.yaml
+++ b/infrastructure/persistence/src/main/resources/application-persistence.yaml
@@ -20,9 +20,6 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: true
-  flyway:
-    clean-disabled: false
-    clean-on-validation-error: true
 ---
 spring:
   config:

--- a/infrastructure/persistence/src/main/resources/db/migration/V13__create_meeting_member.sql
+++ b/infrastructure/persistence/src/main/resources/db/migration/V13__create_meeting_member.sql
@@ -1,0 +1,14 @@
+drop table weave.meeting_team_member;
+create table weave.meeting_member
+(
+    id              binary(16)   not null,
+    meeting_team_id binary(16)   not null,
+    user_id         binary(16)   not null,
+    role            varchar(255) not null,
+    primary key (id),
+    index meeting_member_meeting_team_id_index (meeting_team_id),
+    index meeting_member_user_id_index (user_id)
+);
+
+alter table weave.meeting_team
+    drop column leader_user_id;

--- a/infrastructure/persistence/src/main/resources/db/migration/V13__create_meeting_member.sql
+++ b/infrastructure/persistence/src/main/resources/db/migration/V13__create_meeting_member.sql
@@ -7,7 +7,8 @@ create table weave.meeting_member
     role            varchar(255) not null,
     primary key (id),
     index meeting_member_meeting_team_id_index (meeting_team_id),
-    index meeting_member_user_id_index (user_id)
+    index meeting_member_user_id_index (user_id),
+    unique unique_meeting_member (meeting_team_id, user_id)
 );
 
 alter table weave.meeting_team


### PR DESCRIPTION
## 구현사항
- 내 미팅팀 조회 유스케이스 개발과정에서 일반 유저, 팀장을 구분하는 로직이 복잡해지는 부분이있어 leader를 meeting_member로 정규화했어요.
- 리팩터링 됨에 따라 미팅팀 멤버 추가 메서드를 구현했어요
- 미팅팀에 성별을 추가했어요
- UserQueryUseCase를 추가했어요(타 도메인 조회용)

## 리뷰 요청사항
- 메서드, 변수, 클래스 이름 더 적절한게 생각나면 적극적으로 추천해주세요 
- PR이 좀 커요 지송 🙇
