### PR TITLE
[WEAV-176] 내 미팅팀 조회 유스케이스 구현

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/MeetingTeamGetMyUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/MeetingTeamGetMyUseCase.kt
@@ -16,11 +16,10 @@ interface MeetingTeamGetMyUseCase {
     data class Result(
         override val item: List<MeetingTeamInfo>,
         override val next: UUID?,
-        override val limit: Int,
     ) : ScrollResponse<MeetingTeamInfo, UUID?>(
         item = item,
         next = next,
-        limit = limit,
+        total = item.size,
     )
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingMemberRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingMemberRepository.kt
@@ -14,4 +14,6 @@ interface MeetingMemberRepository {
         userId: UUID
     ): MeetingMember?
 
+    fun findAllMeetingMembersByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember>
+
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingTeamRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingTeamRepository.kt
@@ -9,4 +9,10 @@ interface MeetingTeamRepository {
 
     fun getById(id: UUID): MeetingTeam
 
+    fun findAllByMemberUserId(
+        userId: UUID,
+        next: UUID?,
+        limit: Int,
+    ): List<MeetingTeam>
+
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingTeamRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingTeamRepository.kt
@@ -9,7 +9,7 @@ interface MeetingTeamRepository {
 
     fun getById(id: UUID): MeetingTeam
 
-    fun findAllByMemberUserId(
+    fun scrollByMemberUserId(
         userId: UUID,
         next: UUID?,
         limit: Int,

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamGetMyApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamGetMyApplicationService.kt
@@ -21,7 +21,7 @@ class MeetingTeamGetMyApplicationService(
         val currentUser = getCurrentUserAuthentication().let { userQueryUseCase.getById(it.userId) }
 
         val meetingTeams =
-            meetingDomainService.findAllByMemberUserId(currentUser.id, command.next, command.limit)
+            meetingDomainService.scrollByMemberUserId(currentUser.id, command.next, command.limit)
 
         val meetingTeamInfos = meetingTeams.map { team ->
             val memberInfos = meetingDomainService

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingTeamDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingTeamDomainService.kt
@@ -18,7 +18,7 @@ interface MeetingTeamDomainService {
 
     fun getById(id: UUID): MeetingTeam
 
-    fun findAllByMemberUserId(userId: UUID, next: UUID?, limit: Int): List<MeetingTeam>
+    fun scrollByMemberUserId(userId: UUID, next: UUID?, limit: Int): List<MeetingTeam>
 
     fun findAllMeetingMembersByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember>
 

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingTeamDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingTeamDomainService.kt
@@ -10,12 +10,16 @@ interface MeetingTeamDomainService {
 
     fun save(meetingTeam: MeetingTeam)
 
-    fun getById(id: UUID): MeetingTeam
-
     fun addMember(
         user: User,
         meetingTeam: MeetingTeam,
         role: MeetingMemberRole,
     ): MeetingMember
+
+    fun getById(id: UUID): MeetingTeam
+
+    fun findAllByMemberUserId(userId: UUID, next: UUID?, limit: Int): List<MeetingTeam>
+
+    fun findAllMeetingMembersByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember>
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -25,7 +25,7 @@ class MeetingTeamDomainServiceImpl(
         return meetingTeamRepository.getById(id)
     }
 
-    override fun findAllByMemberUserId(
+    override fun scrollByMemberUserId(
         userId: UUID,
         next: UUID?,
         limit: Int

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -30,7 +30,7 @@ class MeetingTeamDomainServiceImpl(
         next: UUID?,
         limit: Int
     ): List<MeetingTeam> {
-        return meetingTeamRepository.findAllByMemberUserId(userId, next, limit)
+        return meetingTeamRepository.scrollByMemberUserId(userId, next, limit)
     }
 
     override fun findAllMeetingMembersByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember> {

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -25,6 +25,18 @@ class MeetingTeamDomainServiceImpl(
         return meetingTeamRepository.getById(id)
     }
 
+    override fun findAllByMemberUserId(
+        userId: UUID,
+        next: UUID?,
+        limit: Int
+    ): List<MeetingTeam> {
+        return meetingTeamRepository.findAllByMemberUserId(userId, next, limit)
+    }
+
+    override fun findAllMeetingMembersByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember> {
+        return meetingMemberRepository.findAllMeetingMembersByMeetingTeamId(meetingTeamId)
+    }
+
     @Transactional
     override fun addMember(
         user: User,

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/vo/MeetingTeamInfo.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/vo/MeetingTeamInfo.kt
@@ -1,6 +1,7 @@
 package com.studentcenter.weave.application.meeting.vo
 
 import com.studentcenter.weave.domain.meeting.entity.MeetingTeam
+import com.studentcenter.weave.domain.meeting.enums.MeetingMemberRole
 import com.studentcenter.weave.domain.university.entity.University
 import com.studentcenter.weave.domain.user.entity.User
 
@@ -26,7 +27,7 @@ data class MeetingTeamInfo(
     data class MemberInfo(
         val user: User,
         val university: University,
-        val isLeader: Boolean,
+        val role: MeetingMemberRole,
         val isMe: Boolean,
     ) {
 
@@ -35,13 +36,13 @@ data class MeetingTeamInfo(
             fun of(
                 user: User,
                 university: University,
-                isLeader: Boolean,
+                role: MeetingMemberRole,
                 isMe: Boolean,
             ): MemberInfo {
                 return MemberInfo(
                     user = user,
                     university = university,
-                    isLeader = isLeader,
+                    role = role,
                     isMe = isMe,
                 )
             }

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingMemberRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingMemberRepositorySpy.kt
@@ -24,6 +24,10 @@ class MeetingMemberRepositorySpy : MeetingMemberRepository {
         return bucket.values.find { it.meetingTeamId == meetingTeamId && it.userId == userId }
     }
 
+    override fun findAllMeetingMembersByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember> {
+        return bucket.values.filter { it.meetingTeamId == meetingTeamId }
+    }
+
     fun getByMeetingTeamIdAndUserId(
         meetingTeamId: UUID,
         userId: UUID

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingTeamRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingTeamRepositorySpy.kt
@@ -2,10 +2,10 @@ package com.studentcenter.weave.application.meeting.outbound
 
 import com.studentcenter.weave.application.meeting.port.outbound.MeetingTeamRepository
 import com.studentcenter.weave.domain.meeting.entity.MeetingTeam
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
-class MeetingTeamRepositorySpy: MeetingTeamRepository {
+class MeetingTeamRepositorySpy : MeetingTeamRepository {
 
     private val bucket = ConcurrentHashMap<UUID, MeetingTeam>()
 
@@ -15,6 +15,14 @@ class MeetingTeamRepositorySpy: MeetingTeamRepository {
 
     override fun getById(id: UUID): MeetingTeam {
         return bucket[id] ?: throw NoSuchElementException()
+    }
+
+    override fun findAllByMemberUserId(
+        userId: UUID,
+        next: UUID?,
+        limit: Int
+    ): List<MeetingTeam> {
+        return bucket.values.toList()
     }
 
     fun getLast(): MeetingTeam {

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingTeamRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingTeamRepositorySpy.kt
@@ -17,7 +17,7 @@ class MeetingTeamRepositorySpy : MeetingTeamRepository {
         return bucket[id] ?: throw NoSuchElementException()
     }
 
-    override fun findAllByMemberUserId(
+    override fun scrollByMemberUserId(
         userId: UUID,
         next: UUID?,
         limit: Int

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingTeamRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingTeamRestController.kt
@@ -33,7 +33,7 @@ class MeetingTeamRestController(
             MeetingTeamGetMyResponse(
                 item = it.item.map { item -> MeetingTeamGetMyResponse.MeetingTeamDto.from(item) },
                 next = it.next,
-                limit = it.limit,
+                total = it.total
             )
         }
     }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/MeetingTeamGetMyRequest.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/MeetingTeamGetMyRequest.kt
@@ -1,10 +1,14 @@
 package com.studentcenter.weave.bootstrap.meeting.dto
 
 import com.studentcenter.weave.support.common.dto.ScrollRequest
+import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
+@Schema(description = "내 미팅 팀 목록 조회 요청")
 data class MeetingTeamGetMyRequest(
+    @Schema(description = "이전 요청의 마지막 iteam id, 최초 요청시 null")
     override val next: UUID?,
+    @Schema(description = "조회할 개수")
     override val limit: Int
 ) : ScrollRequest<UUID?>(
     next = next,

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/MeetingTeamGetMyResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/MeetingTeamGetMyResponse.kt
@@ -1,17 +1,18 @@
 package com.studentcenter.weave.bootstrap.meeting.dto
 
 import com.studentcenter.weave.application.meeting.vo.MeetingTeamInfo
+import com.studentcenter.weave.domain.meeting.enums.MeetingMemberRole
 import com.studentcenter.weave.support.common.dto.ScrollResponse
 import java.util.*
 
 data class MeetingTeamGetMyResponse(
     override val item: List<MeetingTeamDto>,
     override val next: UUID?,
-    override val limit: Int,
+    override val total: Int,
 ) : ScrollResponse<MeetingTeamGetMyResponse.MeetingTeamDto, UUID?>(
     item = item,
     next = next,
-    limit = limit,
+    total = total,
 ) {
 
     data class MeetingTeamDto(
@@ -45,7 +46,7 @@ data class MeetingTeamGetMyResponse(
         val universityName: String,
         val mbti: String,
         val birthYear: Int,
-        val isLeader: Boolean,
+        val role: MeetingMemberRole,
         val isMe: Boolean,
     ) {
 
@@ -59,7 +60,7 @@ data class MeetingTeamGetMyResponse(
                     universityName = memberInfo.university.name.value,
                     mbti = memberInfo.user.mbti.value,
                     birthYear = memberInfo.user.birthYear.value,
-                    isLeader = memberInfo.isLeader,
+                    role = memberInfo.role,
                     isMe = memberInfo.isMe,
                 )
             }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/user/dto/UserRegisterRequest.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/user/dto/UserRegisterRequest.kt
@@ -12,6 +12,8 @@ data class UserRegisterRequest(
     val gender: Gender,
     val birthYear: Int,
     val mbti: String,
+    @Schema(example = "018d7782-f105-7f0e-9ad9-a47e213037d0")
     val universityId: UUID,
+    @Schema(example = "018d79c6-e9be-7149-806e-7c42a7cd6311")
     val majorId: UUID,
 )

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingMemberJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingMemberJpaAdapter.kt
@@ -28,4 +28,10 @@ class MeetingMemberJpaAdapter(
             ?.toDomain()
     }
 
+    override fun findAllMeetingMembersByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember> {
+        return meetingMemberJpaRepository
+            .findAllByMeetingTeamId(meetingTeamId)
+            .map { it.toDomain() }
+    }
+
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingTeamJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingTeamJpaAdapter.kt
@@ -40,7 +40,6 @@ class MeetingTeamJpaAdapter(
             .findAllByMemberUserId(userId, next, limit)
             .map { it.toDomain() }
 
-        println("result: $result")
         return result
     }
 

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingTeamJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingTeamJpaAdapter.kt
@@ -31,4 +31,17 @@ class MeetingTeamJpaAdapter(
             }.toDomain()
     }
 
+    override fun findAllByMemberUserId(
+        userId: UUID,
+        next: UUID?,
+        limit: Int
+    ): List<MeetingTeam> {
+        val result = meetingTeamJpaRepository
+            .findAllByMemberUserId(userId, next, limit)
+            .map { it.toDomain() }
+
+        println("result: $result")
+        return result
+    }
+
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingTeamJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingTeamJpaAdapter.kt
@@ -31,13 +31,13 @@ class MeetingTeamJpaAdapter(
             }.toDomain()
     }
 
-    override fun findAllByMemberUserId(
+    override fun scrollByMemberUserId(
         userId: UUID,
         next: UUID?,
         limit: Int
     ): List<MeetingTeam> {
         val result = meetingTeamJpaRepository
-            .findAllByMemberUserId(userId, next, limit)
+            .scrollByMemberUserId(userId, next, limit)
             .map { it.toDomain() }
 
         return result

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingMemberJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingMemberJpaRepository.kt
@@ -15,4 +15,6 @@ interface MeetingMemberJpaRepository : JpaRepository<MeetingMemberJpaEntity, UUI
         userId: UUID
     ): MeetingMemberJpaEntity?
 
+    fun findAllByMeetingTeamId(meetingTeamId: UUID): List<MeetingMemberJpaEntity>
+
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingTeamJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingTeamJpaRepository.kt
@@ -23,7 +23,7 @@ interface MeetingTeamJpaRepository : JpaRepository<MeetingTeamJpaEntity, UUID> {
         """,
         nativeQuery = true
     )
-    fun findAllByMemberUserId(
+    fun scrollByMemberUserId(
         memberUserId: UUID,
         next: UUID?,
         limit: Int,

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingTeamJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingTeamJpaRepository.kt
@@ -2,8 +2,32 @@ package com.studentcenter.weave.infrastructure.persistence.meeting.repository
 
 import com.studentcenter.weave.infrastructure.persistence.meeting.entity.MeetingTeamJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.*
 
 @Repository
-interface MeetingTeamJpaRepository : JpaRepository<MeetingTeamJpaEntity, UUID>
+interface MeetingTeamJpaRepository : JpaRepository<MeetingTeamJpaEntity, UUID> {
+
+    // TODO : JOOQ 설정 이후 변경 필요
+    @Query(
+        value =
+        """
+            SELECT mt.id, mt.team_introduce, mt.member_count, mt.location, mt.status, mt.gender
+            FROM meeting_team mt
+            INNER JOIN meeting_member mm ON mt.id = mm.meeting_team_id
+            WHERE mm.user_id = :memberUserId
+            AND (:next IS NULL OR mt.id > :next)
+            ORDER BY mt.id
+            LIMIT :limit
+        """,
+        nativeQuery = true
+    )
+    fun findAllByMemberUserId(
+        memberUserId: UUID,
+        next: UUID?,
+        limit: Int,
+    ): List<MeetingTeamJpaEntity>
+
+
+}

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingTeamJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingTeamJpaRepository.kt
@@ -18,7 +18,7 @@ interface MeetingTeamJpaRepository : JpaRepository<MeetingTeamJpaEntity, UUID> {
             INNER JOIN meeting_member mm ON mt.id = mm.meeting_team_id
             WHERE mm.user_id = :memberUserId
             AND (:next IS NULL OR mt.id > :next)
-            ORDER BY mt.id
+            ORDER BY mt.id DESC
             LIMIT :limit
         """,
         nativeQuery = true

--- a/support/common/src/main/kotlin/com/studentcenter/weave/support/common/dto/ScrollResponse.kt
+++ b/support/common/src/main/kotlin/com/studentcenter/weave/support/common/dto/ScrollResponse.kt
@@ -3,5 +3,5 @@ package com.studentcenter.weave.support.common.dto
 abstract class ScrollResponse<T, N>(
     open val item: List<T>,
     open val next: N,
-    open val limit: Int,
+    open val total: Int,
 )


### PR DESCRIPTION
## 구현사항
- 내 미팅팀 조회 유스케이스 구현했어요

## 논의사항
- 조회 usecase에 대해서도 단위 테스트가 필요할까요?, 조회의 경우 단위테스트보다는 통합테스트가 효용성이 있는것 같아서요
- 현재 암묵적으로 사용하는 클래스 네이밍 컨벤션 중에 도메인 먼저 사용하는 케이스가 있는데,(ex MeetingTeamGetMyUseCase.kt) 여기에 대해서는 자연스러운 문장(GetMyMeetingTeamListUseCase.kt)으로 표현하는게 좋을것 같은데 어떠신가요? (추후 리팩터링 제안)