### PR TITLE
[WEAV-202] 미팅팀 삭제 유스케이스 구현

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/MeetingTeamDeleteUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/MeetingTeamDeleteUseCase.kt
@@ -1,0 +1,13 @@
+package com.studentcenter.weave.application.meeting.port.inbound
+
+import java.util.*
+
+interface MeetingTeamDeleteUseCase {
+
+    fun invoke(command: Command)
+
+    data class Command(
+        val id: UUID,
+    )
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingMemberRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingMemberRepository.kt
@@ -14,6 +14,8 @@ interface MeetingMemberRepository {
         userId: UUID
     ): MeetingMember?
 
-    fun findAllMeetingMembersByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember>
+    fun findAllByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember>
+
+    fun deleteAllByMeetingTeamId(id: UUID)
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingMemberRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingMemberRepository.kt
@@ -16,6 +16,6 @@ interface MeetingMemberRepository {
 
     fun findAllByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember>
 
-    fun deleteAllByMeetingTeamId(id: UUID)
+    fun deleteAllByMeetingTeamId(meetingTeamId: UUID)
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingTeamRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingTeamRepository.kt
@@ -15,4 +15,6 @@ interface MeetingTeamRepository {
         limit: Int,
     ): List<MeetingTeam>
 
+    fun deleteById(id: UUID)
+
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamDeleteApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamDeleteApplicationService.kt
@@ -1,24 +1,19 @@
 package com.studentcenter.weave.application.meeting.service.application
 
 import com.studentcenter.weave.application.meeting.port.inbound.MeetingTeamDeleteUseCase
-import com.studentcenter.weave.application.meeting.port.outbound.MeetingMemberRepository
-import com.studentcenter.weave.application.meeting.port.outbound.MeetingTeamRepository
+import com.studentcenter.weave.application.meeting.service.domain.MeetingTeamDomainService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class MeetingTeamDeleteApplicationService(
-    private val meetingTeamRepository: MeetingTeamRepository,
-    private val meetingMemberRepository: MeetingMemberRepository,
+    private val meetingTeamDomainService: MeetingTeamDomainService,
 ) : MeetingTeamDeleteUseCase {
 
     @Transactional
     override fun invoke(command: MeetingTeamDeleteUseCase.Command) {
-        meetingTeamRepository.getById(command.id)
-            .also {
-                meetingMemberRepository.deleteAllByMeetingTeamId(it.id)
-                meetingTeamRepository.deleteById(it.id)
-            }
+        meetingTeamDomainService.getById(command.id)
+            .let { meetingTeamDomainService.deleteById(it.id) }
     }
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamDeleteApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamDeleteApplicationService.kt
@@ -1,0 +1,24 @@
+package com.studentcenter.weave.application.meeting.service.application
+
+import com.studentcenter.weave.application.meeting.port.inbound.MeetingTeamDeleteUseCase
+import com.studentcenter.weave.application.meeting.port.outbound.MeetingMemberRepository
+import com.studentcenter.weave.application.meeting.port.outbound.MeetingTeamRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MeetingTeamDeleteApplicationService(
+    private val meetingTeamRepository: MeetingTeamRepository,
+    private val meetingMemberRepository: MeetingMemberRepository,
+) : MeetingTeamDeleteUseCase {
+
+    @Transactional
+    override fun invoke(command: MeetingTeamDeleteUseCase.Command) {
+        meetingTeamRepository.getById(command.id)
+            .also {
+                meetingMemberRepository.deleteAllByMeetingTeamId(it.id)
+                meetingTeamRepository.deleteById(it.id)
+            }
+    }
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingTeamDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingTeamDomainService.kt
@@ -16,6 +16,8 @@ interface MeetingTeamDomainService {
         role: MeetingMemberRole,
     ): MeetingMember
 
+    fun deleteById(id: UUID)
+
     fun getById(id: UUID): MeetingTeam
 
     fun scrollByMemberUserId(userId: UUID, next: UUID?, limit: Int): List<MeetingTeam>

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -61,6 +61,11 @@ class MeetingTeamDomainServiceImpl(
         }
     }
 
+    override fun deleteById(id: UUID) {
+        meetingMemberRepository.deleteAllByMeetingTeamId(id)
+        meetingTeamRepository.deleteById(id)
+    }
+
     private fun checkMemberCount(meetingTeam: MeetingTeam) {
         require(meetingMemberRepository.countByMeetingTeamId(meetingTeam.id) < meetingTeam.memberCount) {
             "팀원의 수가 초과되었습니다"

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -34,7 +34,7 @@ class MeetingTeamDomainServiceImpl(
     }
 
     override fun findAllMeetingMembersByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember> {
-        return meetingMemberRepository.findAllMeetingMembersByMeetingTeamId(meetingTeamId)
+        return meetingMemberRepository.findAllByMeetingTeamId(meetingTeamId)
     }
 
     @Transactional

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -61,6 +61,7 @@ class MeetingTeamDomainServiceImpl(
         }
     }
 
+    @Transactional
     override fun deleteById(id: UUID) {
         meetingMemberRepository.deleteAllByMeetingTeamId(id)
         meetingTeamRepository.deleteById(id)

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamDeleteApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamDeleteApplicationServiceTest.kt
@@ -3,6 +3,8 @@ package com.studentcenter.weave.application.meeting.service.application
 import com.studentcenter.weave.application.meeting.outbound.MeetingMemberRepositorySpy
 import com.studentcenter.weave.application.meeting.outbound.MeetingTeamRepositorySpy
 import com.studentcenter.weave.application.meeting.port.inbound.MeetingTeamDeleteUseCase
+import com.studentcenter.weave.application.meeting.service.domain.MeetingTeamDomainService
+import com.studentcenter.weave.application.meeting.service.domain.impl.MeetingTeamDomainServiceImpl
 import com.studentcenter.weave.domain.meeting.entity.MeetingMember
 import com.studentcenter.weave.domain.meeting.entity.MeetingTeamFixtureFactory
 import com.studentcenter.weave.domain.meeting.enums.MeetingMemberRole
@@ -16,10 +18,11 @@ class MeetingTeamDeleteApplicationServiceTest : DescribeSpec({
 
     val meetingTeamRepository = MeetingTeamRepositorySpy()
     val meetingMemberRepository = MeetingMemberRepositorySpy()
-    val sut = MeetingTeamDeleteApplicationService(
+    val meetingTeamDomainService = MeetingTeamDomainServiceImpl(
         meetingTeamRepository,
-        meetingMemberRepository
+        meetingMemberRepository,
     )
+    val sut = MeetingTeamDeleteApplicationService(meetingTeamDomainService)
 
     describe("미팅 팀 삭제 유스케이스") {
         it("해당 미팀팀과 미팅 멤버 정보를 삭제한다") {

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamDeleteApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamDeleteApplicationServiceTest.kt
@@ -46,5 +46,4 @@ class MeetingTeamDeleteApplicationServiceTest : DescribeSpec({
         }
     }
 
-
 })

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamDeleteApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingTeamDeleteApplicationServiceTest.kt
@@ -1,0 +1,50 @@
+package com.studentcenter.weave.application.meeting.service.application
+
+import com.studentcenter.weave.application.meeting.outbound.MeetingMemberRepositorySpy
+import com.studentcenter.weave.application.meeting.outbound.MeetingTeamRepositorySpy
+import com.studentcenter.weave.application.meeting.port.inbound.MeetingTeamDeleteUseCase
+import com.studentcenter.weave.domain.meeting.entity.MeetingMember
+import com.studentcenter.weave.domain.meeting.entity.MeetingTeamFixtureFactory
+import com.studentcenter.weave.domain.meeting.enums.MeetingMemberRole
+import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.stereotype.Service
+
+@Service("meetingTeamDeleteApplicationService")
+class MeetingTeamDeleteApplicationServiceTest : DescribeSpec({
+
+    val meetingTeamRepository = MeetingTeamRepositorySpy()
+    val meetingMemberRepository = MeetingMemberRepositorySpy()
+    val sut = MeetingTeamDeleteApplicationService(
+        meetingTeamRepository,
+        meetingMemberRepository
+    )
+
+    describe("미팅 팀 삭제 유스케이스") {
+        it("해당 미팀팀과 미팅 멤버 정보를 삭제한다") {
+            // arrange
+            val meetingTeam = MeetingTeamFixtureFactory.create()
+            val user1 = UserFixtureFactory.create()
+            val user2 = UserFixtureFactory.create()
+
+            val meetingMember1 =
+                MeetingMember.create(meetingTeam.id, user1.id, MeetingMemberRole.LEADER)
+            val meetingMember2 =
+                MeetingMember.create(meetingTeam.id, user2.id, MeetingMemberRole.MEMBER)
+
+            meetingTeamRepository.save(meetingTeam)
+            meetingMemberRepository.save(meetingMember1)
+            meetingMemberRepository.save(meetingMember2)
+
+            // act
+            sut.invoke(MeetingTeamDeleteUseCase.Command(meetingTeam.id))
+
+            // assert
+            meetingTeamRepository.findById(meetingTeam.id) shouldBe null
+            meetingMemberRepository.findAllByMeetingTeamId(meetingTeam.id) shouldBe emptyList()
+        }
+    }
+
+
+})

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingMemberRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingMemberRepositorySpy.kt
@@ -24,8 +24,12 @@ class MeetingMemberRepositorySpy : MeetingMemberRepository {
         return bucket.values.find { it.meetingTeamId == meetingTeamId && it.userId == userId }
     }
 
-    override fun findAllMeetingMembersByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember> {
+    override fun findAllByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember> {
         return bucket.values.filter { it.meetingTeamId == meetingTeamId }
+    }
+
+    override fun deleteAllByMeetingTeamId(id: UUID) {
+        bucket.values.removeIf { it.meetingTeamId == id }
     }
 
     fun getByMeetingTeamIdAndUserId(

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingMemberRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingMemberRepositorySpy.kt
@@ -28,8 +28,8 @@ class MeetingMemberRepositorySpy : MeetingMemberRepository {
         return bucket.values.filter { it.meetingTeamId == meetingTeamId }
     }
 
-    override fun deleteAllByMeetingTeamId(id: UUID) {
-        bucket.values.removeIf { it.meetingTeamId == id }
+    override fun deleteAllByMeetingTeamId(meetingTeamId: UUID) {
+        bucket.values.removeIf { it.meetingTeamId == meetingTeamId }
     }
 
     fun getByMeetingTeamIdAndUserId(

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingTeamRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingTeamRepositorySpy.kt
@@ -25,6 +25,14 @@ class MeetingTeamRepositorySpy : MeetingTeamRepository {
         return bucket.values.toList()
     }
 
+    override fun deleteById(id: UUID) {
+        bucket.remove(id)
+    }
+
+    fun findById(id: UUID): MeetingTeam? {
+        return bucket[id]
+    }
+
     fun getLast(): MeetingTeam {
         return bucket.values.last()
     }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/api/MeetingTeamApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/api/MeetingTeamApi.kt
@@ -7,11 +7,14 @@ import com.studentcenter.weave.bootstrap.meeting.dto.MeetingTeamGetMyResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
+import java.util.*
 
 @Tag(name = "Meeting Team", description = "Meeting Team API")
 @RequestMapping("/api/meeting-teams")
@@ -33,5 +36,14 @@ interface MeetingTeamApi {
     fun getMyMeetingTeams(
         request: MeetingTeamGetMyRequest
     ): MeetingTeamGetMyResponse
+
+    @Secured
+    @Operation(summary = "Delete meeting team by id")
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteMeetingTeam(
+        @PathVariable
+        id: UUID
+    )
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingTeamRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingTeamRestController.kt
@@ -1,6 +1,7 @@
 package com.studentcenter.weave.bootstrap.meeting.controller
 
 import com.studentcenter.weave.application.meeting.port.inbound.MeetingTeamCreateUseCase
+import com.studentcenter.weave.application.meeting.port.inbound.MeetingTeamDeleteUseCase
 import com.studentcenter.weave.application.meeting.port.inbound.MeetingTeamGetMyUseCase
 import com.studentcenter.weave.bootstrap.meeting.api.MeetingTeamApi
 import com.studentcenter.weave.bootstrap.meeting.dto.MeetingTeamCreateRequest
@@ -8,11 +9,13 @@ import com.studentcenter.weave.bootstrap.meeting.dto.MeetingTeamGetMyRequest
 import com.studentcenter.weave.bootstrap.meeting.dto.MeetingTeamGetMyResponse
 import com.studentcenter.weave.domain.meeting.vo.TeamIntroduce
 import org.springframework.web.bind.annotation.RestController
+import java.util.*
 
 @RestController
 class MeetingTeamRestController(
     private val meetingTeamCreateUseCase: MeetingTeamCreateUseCase,
     private val meetingTeamGetMyUseCase: MeetingTeamGetMyUseCase,
+    private val meetingTeamDeleteUseCase: MeetingTeamDeleteUseCase,
 ) : MeetingTeamApi {
 
     override fun createMeetingTeam(request: MeetingTeamCreateRequest) {
@@ -36,6 +39,11 @@ class MeetingTeamRestController(
                 total = it.total
             )
         }
+    }
+
+    override fun deleteMeetingTeam(id: UUID) {
+        MeetingTeamDeleteUseCase.Command(id)
+            .let { meetingTeamDeleteUseCase.invoke(it) }
     }
 
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingMemberJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingMemberJpaAdapter.kt
@@ -28,10 +28,14 @@ class MeetingMemberJpaAdapter(
             ?.toDomain()
     }
 
-    override fun findAllMeetingMembersByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember> {
+    override fun findAllByMeetingTeamId(meetingTeamId: UUID): List<MeetingMember> {
         return meetingMemberJpaRepository
             .findAllByMeetingTeamId(meetingTeamId)
             .map { it.toDomain() }
+    }
+
+    override fun deleteAllByMeetingTeamId(id: UUID) {
+        meetingMemberJpaRepository.deleteAllByMeetingTeamId(id)
     }
 
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingMemberJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingMemberJpaAdapter.kt
@@ -34,8 +34,8 @@ class MeetingMemberJpaAdapter(
             .map { it.toDomain() }
     }
 
-    override fun deleteAllByMeetingTeamId(id: UUID) {
-        meetingMemberJpaRepository.deleteAllByMeetingTeamId(id)
+    override fun deleteAllByMeetingTeamId(meetingTeamId: UUID) {
+        meetingMemberJpaRepository.deleteAllByMeetingTeamId(meetingTeamId)
     }
 
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingTeamJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingTeamJpaAdapter.kt
@@ -43,4 +43,9 @@ class MeetingTeamJpaAdapter(
         return result
     }
 
+    override fun deleteById(id: UUID) {
+        meetingTeamJpaRepository.deleteById(id)
+    }
+
+
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingMemberJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingMemberJpaRepository.kt
@@ -17,4 +17,6 @@ interface MeetingMemberJpaRepository : JpaRepository<MeetingMemberJpaEntity, UUI
 
     fun findAllByMeetingTeamId(meetingTeamId: UUID): List<MeetingMemberJpaEntity>
 
+    fun deleteAllByMeetingTeamId(id: UUID)
+
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingMemberJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingMemberJpaRepository.kt
@@ -2,6 +2,8 @@ package com.studentcenter.weave.infrastructure.persistence.meeting.repository
 
 import com.studentcenter.weave.infrastructure.persistence.meeting.entity.MeetingMemberJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.util.*
 
@@ -17,6 +19,15 @@ interface MeetingMemberJpaRepository : JpaRepository<MeetingMemberJpaEntity, UUI
 
     fun findAllByMeetingTeamId(meetingTeamId: UUID): List<MeetingMemberJpaEntity>
 
-    fun deleteAllByMeetingTeamId(id: UUID)
+    @Modifying
+    @Query(
+        """
+            DELETE FROM MeetingMemberJpaEntity m
+            WHERE m.meetingTeamId = :teamId 
+        """
+    )
+    fun deleteAllByMeetingTeamId(
+        teamId: UUID
+    )
 
 }


### PR DESCRIPTION
## 구현사항
<img src="https://github.com/Student-Center/weave-server/assets/28651727/3f2fc638-2055-4586-831e-69d2f2934658" alt="drawing" width="200"/>

- request
    - method & path: `[DELETE] /api/meeting-teams/{id}`
        - id : 미팅 팀의 ID
- response
    - 정상 처리된 경우
        - status code: `204 No Content`