### PR TITLE
[WEAV-228] 위치 정보 조회 가독성 수정

### DIFF
--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/enums/Location.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/enums/Location.kt
@@ -5,11 +5,11 @@ enum class Location(
     val isCapitalArea: Boolean,
 ) {
     // 수도권(서울)
-    KONDAE_SEONGSU("건대·성수", true),
-    HONGDAE_SINCHON("홍대·신촌", true),
-    GANGNAM_JAMSIL("강남·잠실", true),
-    NOWON_GONGREUNG("노원·공릉", true),
-    DAEHANGNO_HYEHWA("대학로·혜화", true),
+    KONDAE_SEONGSU("건대•성수", true),
+    HONGDAE_SINCHON("홍대•신촌", true),
+    GANGNAM_JAMSIL("강남•잠실", true),
+    NOWON_GONGREUNG("노원•공릉", true),
+    DAEHANGNO_HYEHWA("대학로•혜화", true),
     // 수도권 (인천, 경기)
     INCHON("인천", true),
     SUWON("수원", true),


### PR DESCRIPTION
![image](https://github.com/Student-Center/weave-server/assets/59856002/45e0fa84-cf72-4ef4-8834-b46db558195c)

가독성을 위해 중간 구분점 큰 것으로 변경하였습니다.

> 건대·성수 -> 건대•성수 