### PR TITLE
[WEAV-231] 미팅팀 멤버 요약 도메인 정의

### DIFF
--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
@@ -1,0 +1,10 @@
+package com.studentcenter.weave.domain.meetingTeam.entity
+
+data class MeetingTeamMemberSummary(
+    val id: String,
+    val meetingTeamId: String,
+    val teamMbti: String,
+    val minAge: Int,
+    val maxAge: Int,
+    val createdAt: String,
+)

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
@@ -2,11 +2,12 @@ package com.studentcenter.weave.domain.meetingTeam.entity
 
 import com.studentcenter.weave.domain.user.vo.BirthYear
 import com.studentcenter.weave.domain.user.vo.Mbti
+import com.studentcenter.weave.support.common.uuid.UuidCreator
 import java.time.LocalDateTime
 import java.util.*
 
 data class MeetingTeamMemberSummary(
-    val id: UUID,
+    val id: UUID = UuidCreator.create(),
     val meetingTeamId: UUID,
     val teamMbti: Mbti,
     val minBirthYear: BirthYear,

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
@@ -16,7 +16,7 @@ data class MeetingTeamMemberSummary(
 
     init {
         require(minBirthYear.value >= maxBirthYear.value) {
-            "최소 년생은 최대 년생보다 클 수 없어요!"
+            "최소 년생은 최대 년생보다 작을 수 없어요!"
         }
     }
 

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
@@ -10,14 +10,14 @@ data class MeetingTeamMemberSummary(
     val id: UUID = UuidCreator.create(),
     val meetingTeamId: UUID,
     val teamMbti: Mbti,
-    val minBirthYear: BirthYear,
-    val maxBirthYear: BirthYear,
+    val youngestMemberBirthYear: BirthYear,
+    val oldestMemberBirthYear: BirthYear,
     val createdAt: LocalDateTime = LocalDateTime.now(),
 ) {
 
     init {
-        require(minBirthYear.value >= maxBirthYear.value) {
-            "최소 년생은 최대 년생보다 작을 수 없어요!"
+        require(youngestMemberBirthYear.value >= oldestMemberBirthYear.value) {
+            "가장 나이가 어린 멤버의 년생은 가장 나이가 많은 멤버의 년생보다 작아야 합니다."
         }
     }
 

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
@@ -1,10 +1,23 @@
 package com.studentcenter.weave.domain.meetingTeam.entity
 
+import com.studentcenter.weave.domain.user.vo.BirthYear
+import com.studentcenter.weave.domain.user.vo.Mbti
+import java.time.LocalDateTime
+import java.util.*
+
 data class MeetingTeamMemberSummary(
-    val id: String,
-    val meetingTeamId: String,
-    val teamMbti: String,
-    val minAge: Int,
-    val maxAge: Int,
-    val createdAt: String,
-)
+    val id: UUID,
+    val meetingTeamId: UUID,
+    val teamMbti: Mbti,
+    val minBirthYear: BirthYear,
+    val maxBirthYear: BirthYear,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+) {
+
+    init {
+        require(minBirthYear.value >= maxBirthYear.value) {
+            "최소 년생은 최대 년생보다 클 수 없어요!"
+        }
+    }
+
+}

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
@@ -13,8 +13,8 @@ class MeetingTeamMemberSummaryJpaEntity(
     id: UUID,
     meetingTeamId: UUID,
     teamMbti: String,
-    minAge: Int,
-    maxAge: Int,
+    minBirthYear: Int,
+    maxBirthYear: Int,
     createdAt: LocalDateTime,
 ) {
 
@@ -31,12 +31,12 @@ class MeetingTeamMemberSummaryJpaEntity(
     var teamMbti: String = teamMbti
         private set
 
-    @Column(name = "min_age", nullable = false)
-    var minAge: Int = minAge
+    @Column(name = "min_birth_year", nullable = false, updatable = false)
+    var minBirthYear: Int = minBirthYear
         private set
 
-    @Column(name = "max_age", nullable = false)
-    var maxAge: Int = maxAge
+    @Column(name = "max_birth_year", nullable = false, updatable = false)
+    var maxBirthYear: Int = maxBirthYear
         private set
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
@@ -1,0 +1,46 @@
+package com.studentcenter.weave.infrastructure.persistence.meetingTeam.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+import java.util.*
+
+@Entity
+@Table(name = "meeting_team_member_summary")
+class MeetingTeamMemberSummaryJpaEntity(
+    id: UUID,
+    meetingTeamId: UUID,
+    teamMbti: String,
+    minAge: Int,
+    maxAge: Int,
+    createdAt: LocalDateTime,
+) {
+
+    @Id
+    @Column(name = "id")
+    var id: UUID = id
+        private set
+
+    @Column(name = "meeting_team_id", nullable = false)
+    var meetingTeamId: UUID = meetingTeamId
+        private set
+
+    @Column(name = "team_mbti", nullable = false, columnDefinition = "varchar(255)")
+    var teamMbti: String = teamMbti
+        private set
+
+    @Column(name = "min_age", nullable = false)
+    var minAge: Int = minAge
+        private set
+
+    @Column(name = "max_age", nullable = false)
+    var maxAge: Int = maxAge
+        private set
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime = createdAt
+        private set
+
+}

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
@@ -23,11 +23,11 @@ class MeetingTeamMemberSummaryJpaEntity(
     var id: UUID = id
         private set
 
-    @Column(name = "meeting_team_id", nullable = false)
+    @Column(name = "meeting_team_id", nullable = false, updatable = false)
     var meetingTeamId: UUID = meetingTeamId
         private set
 
-    @Column(name = "team_mbti", nullable = false, columnDefinition = "varchar(255)")
+    @Column(name = "team_mbti", nullable = false, columnDefinition = "varchar(255)", updatable = false)
     var teamMbti: String = teamMbti
         private set
 

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
@@ -1,5 +1,8 @@
 package com.studentcenter.weave.infrastructure.persistence.meetingTeam.entity
 
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamMemberSummary
+import com.studentcenter.weave.domain.user.vo.BirthYear
+import com.studentcenter.weave.domain.user.vo.Mbti
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
@@ -42,5 +45,30 @@ class MeetingTeamMemberSummaryJpaEntity(
     @Column(name = "created_at", nullable = false, updatable = false)
     var createdAt: LocalDateTime = createdAt
         private set
+
+    companion object {
+
+        fun MeetingTeamMemberSummary.toJpaEntity(): MeetingTeamMemberSummaryJpaEntity {
+            return MeetingTeamMemberSummaryJpaEntity(
+                id = id,
+                meetingTeamId = meetingTeamId,
+                teamMbti = teamMbti.value,
+                minBirthYear = minBirthYear.value,
+                maxBirthYear = maxBirthYear.value,
+                createdAt = createdAt,
+            )
+        }
+    }
+
+    fun toDomainEntity(): MeetingTeamMemberSummary {
+        return MeetingTeamMemberSummary(
+            id = id,
+            meetingTeamId = meetingTeamId,
+            teamMbti = Mbti(teamMbti),
+            minBirthYear = BirthYear(minBirthYear),
+            maxBirthYear = BirthYear(maxBirthYear),
+            createdAt = createdAt,
+        )
+    }
 
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
@@ -60,7 +60,7 @@ class MeetingTeamMemberSummaryJpaEntity(
         }
     }
 
-    fun toDomainEntity(): MeetingTeamMemberSummary {
+    fun toDomain(): MeetingTeamMemberSummary {
         return MeetingTeamMemberSummary(
             id = id,
             meetingTeamId = meetingTeamId,

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/entity/MeetingTeamMemberSummaryJpaEntity.kt
@@ -16,8 +16,8 @@ class MeetingTeamMemberSummaryJpaEntity(
     id: UUID,
     meetingTeamId: UUID,
     teamMbti: String,
-    minBirthYear: Int,
-    maxBirthYear: Int,
+    youngestMemberBirthYear: Int,
+    oldestMemberBirthYear: Int,
     createdAt: LocalDateTime,
 ) {
 
@@ -30,16 +30,21 @@ class MeetingTeamMemberSummaryJpaEntity(
     var meetingTeamId: UUID = meetingTeamId
         private set
 
-    @Column(name = "team_mbti", nullable = false, columnDefinition = "varchar(255)", updatable = false)
+    @Column(
+        name = "team_mbti",
+        nullable = false,
+        columnDefinition = "varchar(255)",
+        updatable = false
+    )
     var teamMbti: String = teamMbti
         private set
 
-    @Column(name = "min_birth_year", nullable = false, updatable = false)
-    var minBirthYear: Int = minBirthYear
+    @Column(name = "youngest_member_birth_year", nullable = false, updatable = false)
+    var youngestMemberBirthYear: Int = youngestMemberBirthYear
         private set
 
-    @Column(name = "max_birth_year", nullable = false, updatable = false)
-    var maxBirthYear: Int = maxBirthYear
+    @Column(name = "oldest_member_birth_year", nullable = false, updatable = false)
+    var oldestMemberBirthYear: Int = oldestMemberBirthYear
         private set
 
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -53,8 +58,8 @@ class MeetingTeamMemberSummaryJpaEntity(
                 id = id,
                 meetingTeamId = meetingTeamId,
                 teamMbti = teamMbti.value,
-                minBirthYear = minBirthYear.value,
-                maxBirthYear = maxBirthYear.value,
+                youngestMemberBirthYear = youngestMemberBirthYear.value,
+                oldestMemberBirthYear = oldestMemberBirthYear.value,
                 createdAt = createdAt,
             )
         }
@@ -65,8 +70,8 @@ class MeetingTeamMemberSummaryJpaEntity(
             id = id,
             meetingTeamId = meetingTeamId,
             teamMbti = Mbti(teamMbti),
-            minBirthYear = BirthYear(minBirthYear),
-            maxBirthYear = BirthYear(maxBirthYear),
+            youngestMemberBirthYear = BirthYear(youngestMemberBirthYear),
+            oldestMemberBirthYear = BirthYear(oldestMemberBirthYear),
             createdAt = createdAt,
         )
     }

--- a/infrastructure/persistence/src/main/resources/db/migration/V14__create_meeting_team_member_summary.sql
+++ b/infrastructure/persistence/src/main/resources/db/migration/V14__create_meeting_team_member_summary.sql
@@ -3,8 +3,8 @@ create table meeting_team_member_summary
     id              binary(16)   not null,
     meeting_team_id binary(16)   not null,
     team_mbti       varchar(255) not null,
-    min_age         int          not null,
-    max_age         int          not null,
+    min_birth_year  int          not null,
+    max_birth_year  int          not null,
     created_at      timestamp    not null,
     primary key (id),
     unique meeting_team_id (meeting_team_id)

--- a/infrastructure/persistence/src/main/resources/db/migration/V14__create_meeting_team_member_summary.sql
+++ b/infrastructure/persistence/src/main/resources/db/migration/V14__create_meeting_team_member_summary.sql
@@ -1,11 +1,11 @@
 create table meeting_team_member_summary
 (
-    id              binary(16)   not null,
-    meeting_team_id binary(16)   not null,
-    team_mbti       varchar(255) not null,
-    min_birth_year  int          not null,
-    max_birth_year  int          not null,
-    created_at      timestamp    not null,
+    id                         binary(16)   not null,
+    meeting_team_id            binary(16)   not null,
+    team_mbti                  varchar(255) not null,
+    youngest_member_birth_year int          not null,
+    oldest_member_birth_year   int          not null,
+    created_at                 timestamp    not null,
     primary key (id),
     unique meeting_team_id (meeting_team_id)
 ) engine = innodb

--- a/infrastructure/persistence/src/main/resources/db/migration/V14__create_meeting_team_member_summary.sql
+++ b/infrastructure/persistence/src/main/resources/db/migration/V14__create_meeting_team_member_summary.sql
@@ -1,0 +1,12 @@
+create table meeting_team_member_summary
+(
+    id              binary(16)   not null,
+    meeting_team_id binary(16)   not null,
+    team_mbti       varchar(255) not null,
+    min_age         int          not null,
+    max_age         int          not null,
+    created_at      timestamp    not null,
+    primary key (id),
+    unique meeting_team_id (meeting_team_id)
+) engine = innodb
+  default charset = utf8mb4;


### PR DESCRIPTION
## Background

**MeetingTeamMemberSummary**

- 미팅 팀 확정시 생성되는 팀내 멤버 정보 대한 요약 도메인
    - 목록조회시 필터 (가장 어린 년생, 가장 나이많은 년생)
    - 상세 조회시 케미(팀 MBTI)

## Goals & Non-Goals

### Goals

- 미팅팀 멤버 요약 도메인 정의

## **Methodology & Design(Proposal)**

### Data modeling

```mermaid
erDiagram
    MeetingTeamEntity ||--|| MeetingTeamMemberSummaryEntity : has
    MeetingTeamEntity {
        UUID id
    }
    MeetingTeamMemberSummaryEntity {
        UUID id
        UUID meeting_team_id
        string team_mbti
        int youngest_member_birth_year
        int oldest_member_birth_year
        LocalDateTime created_at
    }
```

## Schedule

- [x]  엔티티 정의 (DDL)
- [x]  도메인 정의 (data class)