### PR TITLE
[WEAV-236] 대표 MBTI 계산 로직 작성

### DIFF
--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/user/vo/Mbti.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/user/vo/Mbti.kt
@@ -1,11 +1,44 @@
 package com.studentcenter.weave.domain.user.vo
 
 @JvmInline
-value class Mbti (
-    val value: String
-){
+value class Mbti(val value: String) {
+
     companion object {
-        const val VALIDATION_REGEX = "^(I|E|i|e)(S|N|s|n)(T|F|t|f)(J|P|j|p)"
+
+        private const val VALIDATION_REGEX = "^(I|E|i|e)(S|N|s|n)(T|F|t|f)(J|P|j|p)\$"
+        private const val MBTI_UPPERCASE_SCORE = 2
+        private const val MBTI_LOWERCASE_SCORE = 1
+
+        fun getDominantMbti(mbtis: List<Mbti>): Mbti {
+            val mbtiScores = mutableMapOf(
+                'E' to 0, 'I' to 0, 'N' to 0, 'S' to 0, 'F' to 0, 'T' to 0, 'P' to 0, 'J' to 0
+            )
+
+            mbtis.forEach { mbti ->
+                mbti.value.forEach {
+                    val key = it.uppercaseChar()
+                    val score = if (it.isUpperCase()) MBTI_UPPERCASE_SCORE else MBTI_LOWERCASE_SCORE
+                    mbtiScores[key] = mbtiScores.getOrDefault(key, 0) + score
+                }
+            }
+
+            return Mbti(buildString {
+                append(selectDominantTrait('E', 'I', mbtiScores))
+                append(selectDominantTrait('N', 'S', mbtiScores))
+                append(selectDominantTrait('F', 'T', mbtiScores))
+                append(selectDominantTrait('P', 'J', mbtiScores))
+            })
+        }
+
+        private fun selectDominantTrait(
+            trait1: Char,
+            trait2: Char,
+            scores: Map<Char, Int>
+        ): Char {
+            val score1 = scores.getOrDefault(trait1, 0)
+            val score2 = scores.getOrDefault(trait2, 0)
+            return if (score1 >= score2) trait1 else trait2
+        }
     }
 
     init {
@@ -13,5 +46,4 @@ value class Mbti (
             "MBTI는 I/E, S/N, T/F, J/P로 이루어진 4글자의 문자열이어야 합니다.(소문자 허용)"
         }
     }
-
 }

--- a/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/MbtiTest.kt
+++ b/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/MbtiTest.kt
@@ -1,6 +1,7 @@
 package com.studentcenter.weave.domain.user.vo
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 class MbtiTest : FunSpec({
@@ -25,6 +26,34 @@ class MbtiTest : FunSpec({
 
         runCatching { Mbti("EnT!") }
             .exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
+    }
+
+    test("대표 MBTI 계산 - 1") {
+        val mbtis = listOf(
+            Mbti("EnTJ"),
+            Mbti("ISTP"),
+            Mbti("ESFJ"),
+            Mbti("INFP"),
+            Mbti("enFp")
+        )
+        Mbti.getDominantMbti(mbtis).value shouldBe "ENFP"
+    }
+
+    test("대표 MBTI 계산 - 2") {
+        val mbtis = listOf(
+            Mbti("EnTJ"),
+            Mbti("ISTP"),
+            Mbti("ESFJ"),
+        )
+        Mbti.getDominantMbti(mbtis).value shouldBe "ESTJ"
+    }
+
+    test("대표 MBTI 계산 - 3") {
+        val mbtis = listOf(
+            Mbti("EnTJ"),
+            Mbti("ISTP"),
+        )
+        Mbti.getDominantMbti(mbtis).value shouldBe "ESTP"
     }
 
 })

--- a/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/MbtiTest.kt
+++ b/domain/src/test/kotlin/com/studentcenter/weave/domain/user/vo/MbtiTest.kt
@@ -6,54 +6,54 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 
 class MbtiTest : FunSpec({
 
-    test("MBTI 형식 테스트 1") {
-        Mbti("EnTJ")
-        Mbti("ISTP")
-        Mbti("ESFJ")
-        Mbti("INFP")
-        Mbti("enFp")
-    }
-
-    test("MBTI 형식 테스트 2") {
-        runCatching { Mbti("EnT") }
-            .exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
-
-        runCatching { Mbti("EnTJJ") }
-            .exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
-
-        runCatching { Mbti("EnT1") }
-            .exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
-
-        runCatching { Mbti("EnT!") }
-            .exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
-    }
-
-    test("대표 MBTI 계산 - 1") {
-        val mbtis = listOf(
-            Mbti("EnTJ"),
-            Mbti("ISTP"),
-            Mbti("ESFJ"),
-            Mbti("INFP"),
+    context("MBTI 유효성 검사") {
+        test("유효한 MBTI 형식 검사") {
+            Mbti("EnTJ")
+            Mbti("ISTP")
+            Mbti("ESFJ")
+            Mbti("INFP")
             Mbti("enFp")
-        )
-        Mbti.getDominantMbti(mbtis).value shouldBe "ENFP"
+        }
+
+        test("유효하지 않은 MBTI 형식 검사") {
+            runCatching { Mbti("EnT") }.exceptionOrNull()
+                ?.shouldBeInstanceOf<IllegalArgumentException>()
+            runCatching { Mbti("EnTJJ") }.exceptionOrNull()
+                ?.shouldBeInstanceOf<IllegalArgumentException>()
+            runCatching { Mbti("EnT1") }.exceptionOrNull()
+                ?.shouldBeInstanceOf<IllegalArgumentException>()
+            runCatching { Mbti("EnT!") }.exceptionOrNull()
+                ?.shouldBeInstanceOf<IllegalArgumentException>()
+        }
     }
 
-    test("대표 MBTI 계산 - 2") {
-        val mbtis = listOf(
-            Mbti("EnTJ"),
-            Mbti("ISTP"),
-            Mbti("ESFJ"),
-        )
-        Mbti.getDominantMbti(mbtis).value shouldBe "ESTJ"
-    }
+    context("대표 MBTI 계산") {
+        test("대표 MBTI 계산 - 다수의 MBTI") {
+            val mbtis = listOf(
+                Mbti("EnTJ"),
+                Mbti("ISTP"),
+                Mbti("ESFJ"),
+                Mbti("INFP"),
+                Mbti("enFp")
+            )
+            Mbti.getDominantMbti(mbtis).value shouldBe "ENFP"
+        }
 
-    test("대표 MBTI 계산 - 3") {
-        val mbtis = listOf(
-            Mbti("EnTJ"),
-            Mbti("ISTP"),
-        )
-        Mbti.getDominantMbti(mbtis).value shouldBe "ESTP"
-    }
+        test("대표 MBTI 계산 - 3개의 MBTI") {
+            val mbtis = listOf(
+                Mbti("EnTJ"),
+                Mbti("ISTP"),
+                Mbti("ESFJ"),
+            )
+            Mbti.getDominantMbti(mbtis).value shouldBe "ESTJ"
+        }
 
+        test("대표 MBTI 계산 - 2개의 MBTI") {
+            val mbtis = listOf(
+                Mbti("EnTJ"),
+                Mbti("ISTP"),
+            )
+            Mbti.getDominantMbti(mbtis).value shouldBe "ESTP"
+        }
+    }
 })


### PR DESCRIPTION
## getDominantMbti
- 주어진 MBTI 유형들의 목록에서 가장 우세한 성격 유형을 결정하는 로직을 구현했어요
- MBTI_UPPERCASE_SCORE와 MBTI_LOWERCASE_SCORE: 대문자 MBTI 지표는 2점, 소문자는 1점의 가중치를 두어, 대문자로 표시된 성격 특성을 더 강하게 표현해요

## 작동 방식

1. 초기에 mbtiScores 맵은 각 MBTI 성격 지표(E, I, N, S, F, T, P, J)를 키로 하고, 각각의 초기 점수를 0으로 설정해요

2. 주어진 mbtis 목록을 순회하며, 각 MBTI 유형의 문자를 대문자로 변환하고, 해당 문자가 대문자인지 여부에 따라 점수(대문자는 2점, 소문자는 1점)를 부여하고, 각 문자의 점수는 mbtiScores 맵에 누적해요

3. 모든 MBTI 유형에 대해 점수를 계산한 후, buildString을 사용하여 새로운 MBTI 유형 문자열을 생성해요. 네 개의 성격 차원 각각에 대해 selectDominantTrait 함수를 호출하여 우세한 특성(E/I, S/N, F/T, J/P)을 선택하는 방식으로 진행돼요

4. selectDominantTrait 함수는 두 성격 지표(예: E와 I)의 점수를 비교하고, 더 높은 점수를 가진 특성을 반환해요. 점수가 같은 경우 첫 번째 특성(이 예에서는 E)을 반환해요