### PR TITLE
[WEAV-227] 미팅팀 나가기 API 구현

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/common/exception/MeetingTeamExceptionType.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/common/exception/MeetingTeamExceptionType.kt
@@ -1,0 +1,8 @@
+package com.studentcenter.weave.application.common.exception
+
+import com.studentcenter.weave.support.common.exception.CustomExceptionType
+
+enum class MeetingTeamExceptionType (override val code: String): CustomExceptionType {
+    IS_NOT_TEAM_MEMBER("MEETING-TEAM-001"),
+    LEADER_CANNOT_LEAVE_TEAM("MEETING-TEAM-002"),
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/inbound/MeetingTeamLeaveUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/inbound/MeetingTeamLeaveUseCase.kt
@@ -1,0 +1,13 @@
+package com.studentcenter.weave.application.meetingTeam.port.inbound
+
+import java.util.*
+
+fun interface MeetingTeamLeaveUseCase {
+
+    fun invoke(command: Command)
+
+    data class Command(
+        val teamId: UUID,
+    )
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/inbound/MeetingTeamLeaveUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/inbound/MeetingTeamLeaveUseCase.kt
@@ -6,8 +6,6 @@ fun interface MeetingTeamLeaveUseCase {
 
     fun invoke(command: Command)
 
-    data class Command(
-        val teamId: UUID,
-    )
+    data class Command(val meetingTeamId: UUID)
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/outbound/MeetingMemberRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/outbound/MeetingMemberRepository.kt
@@ -18,4 +18,6 @@ interface MeetingMemberRepository {
 
     fun deleteAllByMeetingTeamId(meetingTeamId: UUID)
 
+    fun deleteById(id: UUID)
+
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationService.kt
@@ -15,12 +15,7 @@ class MeetingTeamLeaveApplicationService(
     override fun invoke(command: MeetingTeamLeaveUseCase.Command) {
         getCurrentUserAuthentication()
             .userId
-            .also {
-                meetingTeamDomainService.deleteMember(
-                    memberUserId = it,
-                    command.teamId
-                )
-            }
+            .also { meetingTeamDomainService.deleteMember(it, command.meetingTeamId) }
     }
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationService.kt
@@ -1,0 +1,26 @@
+package com.studentcenter.weave.application.meetingTeam.service.application
+
+import com.studentcenter.weave.application.common.security.context.getCurrentUserAuthentication
+import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamLeaveUseCase
+import com.studentcenter.weave.application.meetingTeam.service.domain.MeetingTeamDomainService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class MeetingTeamLeaveApplicationService(
+    private val meetingTeamDomainService: MeetingTeamDomainService,
+) : MeetingTeamLeaveUseCase {
+
+    @Transactional
+    override fun invoke(command: MeetingTeamLeaveUseCase.Command) {
+        getCurrentUserAuthentication()
+            .userId
+            .also {
+                meetingTeamDomainService.deleteMember(
+                    memberUserId = it,
+                    command.teamId
+                )
+            }
+    }
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/MeetingTeamDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/MeetingTeamDomainService.kt
@@ -27,6 +27,11 @@ interface MeetingTeamDomainService {
 
     fun deleteById(id: UUID)
 
+    fun deleteMember(
+        memberUserId: UUID,
+        teamId: UUID
+    )
+
     fun getById(id: UUID): MeetingTeam
 
     fun scrollByMemberUserId(

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.studentcenter.weave.application.meetingTeam.service.domain.impl
 
+import com.studentcenter.weave.application.common.exception.MeetingTeamExceptionType
 import com.studentcenter.weave.application.meetingTeam.port.outbound.MeetingMemberRepository
 import com.studentcenter.weave.application.meetingTeam.port.outbound.MeetingTeamRepository
 import com.studentcenter.weave.application.meetingTeam.service.domain.MeetingTeamDomainService
@@ -9,6 +10,7 @@ import com.studentcenter.weave.domain.meetingTeam.enums.Location
 import com.studentcenter.weave.domain.meetingTeam.enums.MeetingMemberRole
 import com.studentcenter.weave.domain.meetingTeam.vo.TeamIntroduce
 import com.studentcenter.weave.domain.user.entity.User
+import com.studentcenter.weave.support.common.exception.CustomException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -109,6 +111,40 @@ class MeetingTeamDomainServiceImpl(
     override fun deleteById(id: UUID) {
         meetingMemberRepository.deleteAllByMeetingTeamId(id)
         meetingTeamRepository.deleteById(id)
+    }
+
+    @Transactional
+    override fun deleteMember(
+        memberUserId: UUID,
+        teamId: UUID
+    ) {
+        verifyIsTeamMember(teamId, memberUserId)
+            .also {
+                verifyIsNotTeamLeader(it)
+                meetingMemberRepository.deleteById(it.id)
+            }
+    }
+
+    private fun verifyIsTeamMember(
+        teamId: UUID,
+        userId: UUID
+    ): MeetingMember {
+        return meetingMemberRepository
+            .findAllByMeetingTeamId(teamId)
+            .findLast { it.userId == userId }
+            ?: throw CustomException(
+                type = MeetingTeamExceptionType.IS_NOT_TEAM_MEMBER,
+                message = "미팅 팀 멤버가 아니에요!"
+            )
+    }
+
+    private fun verifyIsNotTeamLeader(meetingMember: MeetingMember) {
+        if (meetingMember.role == MeetingMemberRole.LEADER) {
+            throw CustomException(
+                type = MeetingTeamExceptionType.LEADER_CANNOT_LEAVE_TEAM,
+                message = "팀장은 팀을 나갈 수 없어요!"
+            )
+        }
     }
 
     private fun checkMemberCount(meetingTeam: MeetingTeam) {

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -130,8 +130,7 @@ class MeetingTeamDomainServiceImpl(
         userId: UUID
     ): MeetingMember {
         return meetingMemberRepository
-            .findAllByMeetingTeamId(teamId)
-            .findLast { it.userId == userId }
+            .findByMeetingTeamIdAndUserId(teamId, userId)
             ?: throw CustomException(
                 type = MeetingTeamExceptionType.IS_NOT_TEAM_MEMBER,
                 message = "미팅 팀 멤버가 아니에요!"
@@ -142,7 +141,7 @@ class MeetingTeamDomainServiceImpl(
         if (meetingMember.role == MeetingMemberRole.LEADER) {
             throw CustomException(
                 type = MeetingTeamExceptionType.LEADER_CANNOT_LEAVE_TEAM,
-                message = "팀장은 팀을 나갈 수 없어요!"
+                message = "팀장은 팀을 나갈 수 없어요! - 팀을 삭제해주세요!"
             )
         }
     }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -118,14 +118,14 @@ class MeetingTeamDomainServiceImpl(
         memberUserId: UUID,
         teamId: UUID
     ) {
-        verifyIsTeamMember(teamId, memberUserId)
+        getTeamMember(teamId, memberUserId)
             .also {
                 verifyIsNotTeamLeader(it)
                 meetingMemberRepository.deleteById(it.id)
             }
     }
 
-    private fun verifyIsTeamMember(
+    private fun getTeamMember(
         teamId: UUID,
         userId: UUID
     ): MeetingMember {

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationServiceTest.kt
@@ -1,0 +1,124 @@
+package com.studentcenter.weave.application.meetingTeam.service.application
+
+import com.studentcenter.weave.application.common.exception.MeetingTeamExceptionType
+import com.studentcenter.weave.application.common.security.context.UserSecurityContext
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingMemberRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamLeaveUseCase
+import com.studentcenter.weave.application.meetingTeam.service.domain.impl.MeetingTeamDomainServiceImpl
+import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingMember
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
+import com.studentcenter.weave.domain.meetingTeam.enums.MeetingMemberRole
+import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import com.studentcenter.weave.support.common.exception.CustomException
+import com.studentcenter.weave.support.security.context.SecurityContextHolder
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+@DisplayName("MeetingTeamLeaveApplicationService")
+class MeetingTeamLeaveApplicationServiceTest : DescribeSpec({
+
+    val meetingMemberRepository = MeetingMemberRepositorySpy()
+    val meetingTeamRepository = MeetingTeamRepositorySpy()
+    val meetingTeamDomainService = MeetingTeamDomainServiceImpl(
+        meetingMemberRepository = meetingMemberRepository,
+        meetingTeamRepository = meetingTeamRepository
+    )
+    val sut = MeetingTeamLeaveApplicationService(meetingTeamDomainService)
+
+    afterEach {
+        meetingMemberRepository.clear()
+        meetingTeamRepository.clear()
+        SecurityContextHolder.clearContext()
+    }
+
+    describe("미팅팀 나가기 유스케이스") {
+        context("유저가 해당팀의 멤버이고, 팀원일때") {
+            it("팀에서 나간다") {
+                // arrange
+                val meetingTeam = MeetingTeamFixtureFactory.create()
+                val user = UserFixtureFactory.create()
+                val userAuthentication = UserAuthentication(
+                    userId = user.id,
+                    email = user.email,
+                    nickname = user.nickname,
+                    avatar = null,
+                )
+                SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
+
+                val meetingMember = MeetingMember.create(
+                    userId = user.id,
+                    meetingTeamId = meetingTeam.id,
+                    role = MeetingMemberRole.MEMBER,
+                )
+
+                meetingMemberRepository.save(meetingMember)
+                meetingTeamRepository.save(meetingTeam)
+
+                // act
+                sut.invoke(MeetingTeamLeaveUseCase.Command(meetingTeam.id))
+
+                // assert
+                val member =
+                    meetingMemberRepository.findByMeetingTeamIdAndUserId(meetingTeam.id, user.id)
+                member shouldBe null
+            }
+        }
+
+        context("유저가 해당팀의 멤버가 아닐때") {
+            it("팀원이 아니라는 예외를 발생시킨다.") {
+                // arrange
+                val meetingTeam = MeetingTeamFixtureFactory.create()
+                val user = UserFixtureFactory.create()
+                val userAuthentication = UserAuthentication(
+                    userId = user.id,
+                    email = user.email,
+                    nickname = user.nickname,
+                    avatar = null,
+                )
+                SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
+                meetingTeamRepository.save(meetingTeam)
+
+                // act, assert
+                val exception: CustomException = shouldThrow<CustomException> {
+                    sut.invoke(MeetingTeamLeaveUseCase.Command(meetingTeam.id))
+                }
+                exception.type shouldBe MeetingTeamExceptionType.IS_NOT_TEAM_MEMBER
+            }
+        }
+
+        context("유저가 해당팀의 멤버이고, 팀장일때") {
+            it("팀장은 나갈 수 없다는 예외를 발생시킨다.") {
+                // arrange
+                val meetingTeam = MeetingTeamFixtureFactory.create()
+                val user = UserFixtureFactory.create()
+                val userAuthentication = UserAuthentication(
+                    userId = user.id,
+                    email = user.email,
+                    nickname = user.nickname,
+                    avatar = null,
+                )
+                SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
+
+                val meetingMember = MeetingMember.create(
+                    userId = user.id,
+                    meetingTeamId = meetingTeam.id,
+                    role = MeetingMemberRole.LEADER,
+                )
+
+                meetingMemberRepository.save(meetingMember)
+                meetingTeamRepository.save(meetingTeam)
+
+                // act, assert
+                val exception: CustomException = shouldThrow<CustomException> {
+                    sut.invoke(MeetingTeamLeaveUseCase.Command(meetingTeam.id))
+                }
+                exception.type shouldBe MeetingTeamExceptionType.LEADER_CANNOT_LEAVE_TEAM
+            }
+        }
+    }
+
+})

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/outbound/MeetingMemberRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/outbound/MeetingMemberRepositorySpy.kt
@@ -32,6 +32,10 @@ class MeetingMemberRepositorySpy : MeetingMemberRepository {
         bucket.values.removeIf { it.meetingTeamId == meetingTeamId }
     }
 
+    override fun deleteById(id: UUID) {
+        bucket.remove(id)
+    }
+
     fun getByMeetingTeamIdAndUserId(
         meetingTeamId: UUID,
         userId: UUID

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/api/MeetingTeamApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/api/MeetingTeamApi.kt
@@ -84,4 +84,13 @@ interface MeetingTeamApi {
         request: MeetingTeamGetListRequest
     ): MeetingTeamGetListResponse
 
+    @Operation(summary = "Leave meeting team")
+    @PostMapping("/{id}/leave")
+    @Secured
+    @ResponseStatus(HttpStatus.OK)
+    fun leaveMeetingTeam(
+        @PathVariable
+        id: UUID
+    )
+
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/api/MeetingTeamApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/api/MeetingTeamApi.kt
@@ -84,10 +84,10 @@ interface MeetingTeamApi {
         request: MeetingTeamGetListRequest
     ): MeetingTeamGetListResponse
 
-    @Operation(summary = "Leave meeting team")
-    @PostMapping("/{id}/leave")
     @Secured
-    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Leave meeting team")
+    @DeleteMapping("/{id}/members/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun leaveMeetingTeam(
         @PathVariable
         id: UUID

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/controller/MeetingTeamRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/controller/MeetingTeamRestController.kt
@@ -5,6 +5,7 @@ import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamD
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamEditUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamGetDetailUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamGetMyUseCase
+import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamLeaveUseCase
 import com.studentcenter.weave.bootstrap.meetingTeam.api.MeetingTeamApi
 import com.studentcenter.weave.bootstrap.meetingTeam.dto.MeetingTeamCreateRequest
 import com.studentcenter.weave.bootstrap.meetingTeam.dto.MeetingTeamEditRequest
@@ -26,6 +27,7 @@ class MeetingTeamRestController(
     private val meetingTeamDeleteUseCase: MeetingTeamDeleteUseCase,
     private val meetingTeamEditUseCase: MeetingTeamEditUseCase,
     private val meetingTeamGetDetailUseCase: MeetingTeamGetDetailUseCase,
+    private val meetingTeamLeaveUseCase: MeetingTeamLeaveUseCase,
 ) : MeetingTeamApi {
 
     override fun createMeetingTeam(request: MeetingTeamCreateRequest) {
@@ -143,6 +145,10 @@ class MeetingTeamRestController(
             next = UUID.randomUUID(),
             total = 2,
         )
+    }
+
+    override fun leaveMeetingTeam(id: UUID) {
+        meetingTeamLeaveUseCase.invoke(MeetingTeamLeaveUseCase.Command(id))
     }
 
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/adapter/MeetingMemberJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/adapter/MeetingMemberJpaAdapter.kt
@@ -38,4 +38,8 @@ class MeetingMemberJpaAdapter(
         meetingMemberJpaRepository.deleteAllByMeetingTeamId(meetingTeamId)
     }
 
+    override fun deleteById(id: UUID) {
+        meetingMemberJpaRepository.deleteById(id)
+    }
+
 }


### PR DESCRIPTION
## Background

<img src="https://github.com/Student-Center/weave-server/assets/28651727/d5f5892f-b770-440e-ba5f-64bc4ef281de" width=400px>

- 내팀화면, 멤버의 미팅팀 나가기 기능 개발

## Goals & Non-Goals

### Goals

- 멤버의 미팅팀 나가기
    - 만약 팀이 공개된 상태(status = PUBLISH)일 경우 나갈 수 없다.
    - 만약 유저가 해당 팀에 속해 있지 않을 경우 나갈 수 없다.
    - 만약 유저가 해당 팀의 멤버가 아닌경우(리더인 경우) 나갈 수 없다.

## **Methodology & Design(Proposal)**

### API

**POST /api/meeting-teams/{id}/leave**

- **Auth Required:** Yes (토큰 기반 인증을 사용, 요청 헤더에 **`Authorization: Bearer <token>`** 포함)
- **Request**
    - method & path: `[DELETE] /api/meeting-teams/{id}/members/me`
- **Response**
    - 정상 처리된 경우
        - status code: `200 OK`