### PR TITLE
[WEAV-237] User Access Token Claims gender 추가

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/user/service/util/impl/UserTokenServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/user/service/util/impl/UserTokenServiceImpl.kt
@@ -8,6 +8,7 @@ import com.studentcenter.weave.application.user.service.util.impl.strategy.OpenI
 import com.studentcenter.weave.application.user.service.util.impl.strategy.OpenIdTokenResolveStrategyFactory
 import com.studentcenter.weave.application.user.vo.UserTokenClaims
 import com.studentcenter.weave.domain.user.entity.User
+import com.studentcenter.weave.domain.user.enums.Gender
 import com.studentcenter.weave.domain.user.enums.SocialLoginProvider
 import com.studentcenter.weave.domain.user.vo.Nickname
 import com.studentcenter.weave.support.common.vo.Email
@@ -82,6 +83,7 @@ class UserTokenServiceImpl(
                 this["userId"] = user.id.toString()
                 this["nickname"] = user.nickname.value
                 this["email"] = user.email.value
+                this["gender"] = user.gender.name
                 user.avatar?.let { this["avatar"] = it.value }
             }
         }
@@ -99,6 +101,7 @@ class UserTokenServiceImpl(
             nickname = Nickname(jwtClaims.customClaims["nickname"] as String),
             email = Email(jwtClaims.customClaims["email"] as String),
             avatar = (jwtClaims.customClaims["avatar"] as String?)?.let { Url(it) },
+            gender = (jwtClaims.customClaims["gender"] as String).let { Gender.valueOf(it) }
         )
     }
 

--- a/application/src/main/kotlin/com/studentcenter/weave/application/user/vo/UserAuthentication.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/user/vo/UserAuthentication.kt
@@ -1,5 +1,6 @@
 package com.studentcenter.weave.application.user.vo
 
+import com.studentcenter.weave.domain.user.enums.Gender
 import com.studentcenter.weave.domain.user.vo.Nickname
 import com.studentcenter.weave.support.common.vo.Email
 import com.studentcenter.weave.support.common.vo.Url
@@ -11,16 +12,17 @@ data class UserAuthentication(
     val nickname: Nickname,
     val email: Email,
     val avatar: Url?,
+    val gender: Gender,
 ) : Authentication {
 
     companion object {
-
         fun from(claims: UserTokenClaims.AccessToken): UserAuthentication {
             return UserAuthentication(
                 userId = claims.userId,
                 nickname = claims.nickname,
                 email = claims.email,
-                avatar = claims.avatar
+                avatar = claims.avatar,
+                gender = claims.gender
             )
         }
     }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/user/vo/UserTokenClaims.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/user/vo/UserTokenClaims.kt
@@ -1,5 +1,6 @@
 package com.studentcenter.weave.application.user.vo
 
+import com.studentcenter.weave.domain.user.enums.Gender
 import com.studentcenter.weave.domain.user.enums.SocialLoginProvider
 import com.studentcenter.weave.domain.user.vo.Nickname
 import com.studentcenter.weave.support.common.vo.Email
@@ -18,6 +19,7 @@ sealed class UserTokenClaims {
         val nickname: Nickname,
         val email: Email,
         val avatar: Url?,
+        val gender: Gender,
     ) : UserTokenClaims()
 
     data class RegisterToken(

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateApplicationServiceTest.kt
@@ -8,6 +8,7 @@ import com.studentcenter.weave.application.meetingTeam.service.domain.impl.Meeti
 import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCaseStub
 import com.studentcenter.weave.application.user.port.outbound.UserRepositorySpy
 import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.enums.Location
 import com.studentcenter.weave.domain.meetingTeam.vo.TeamIntroduce
 import com.studentcenter.weave.domain.user.entity.User
@@ -57,12 +58,9 @@ class MeetingTeamCreateApplicationServiceTest : DescribeSpec({
 
                 val leaderUserFixture: User = UserFixtureFactory.create()
                 userRepositorySpy.save(leaderUserFixture)
-                UserAuthentication(
-                    userId = leaderUserFixture.id,
-                    email = leaderUserFixture.email,
-                    nickname = leaderUserFixture.nickname,
-                    avatar = leaderUserFixture.avatar
-                ).let { SecurityContextHolder.setContext(UserSecurityContext(it)) }
+                UserAuthenticationFixtureFactory
+                    .create(leaderUserFixture)
+                    .let { SecurityContextHolder.setContext(UserSecurityContext(it)) }
 
                 // act
                 sut.invoke(command)

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamEditApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamEditApplicationServiceTest.kt
@@ -6,6 +6,7 @@ import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamRepos
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamEditUseCase
 import com.studentcenter.weave.application.meetingTeam.service.domain.impl.MeetingTeamDomainServiceImpl
 import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingMember
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.enums.Location
@@ -51,12 +52,7 @@ class MeetingTeamEditApplicationServiceTest : DescribeSpec({
                 )
                 meetingMemberRepository.save(meetingMember)
                 meetingTeamRepository.save(meetingTeam)
-                val userAuthentication = UserAuthentication(
-                    userId = currentUser.id,
-                    email = currentUser.email,
-                    nickname = currentUser.nickname,
-                    avatar = currentUser.avatar
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(currentUser)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                 // act & assert
@@ -89,12 +85,7 @@ class MeetingTeamEditApplicationServiceTest : DescribeSpec({
                 )
                 meetingMemberRepository.save(meetingMember)
                 meetingTeamRepository.save(meetingTeam)
-                val userAuthentication = UserAuthentication(
-                    userId = currentUser.id,
-                    email = currentUser.email,
-                    nickname = currentUser.nickname,
-                    avatar = currentUser.avatar
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(currentUser)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                 // act
@@ -144,12 +135,7 @@ class MeetingTeamEditApplicationServiceTest : DescribeSpec({
                 meetingMemberRepository.save(member2)
                 meetingTeamRepository.save(meetingTeam)
 
-                val userAuthentication = UserAuthentication(
-                    userId = currentUser.id,
-                    email = currentUser.email,
-                    nickname = currentUser.nickname,
-                    avatar = currentUser.avatar
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(currentUser)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                 // act & assert

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationServiceTest.kt
@@ -6,7 +6,7 @@ import com.studentcenter.weave.application.meetingTeam.outbound.MeetingMemberRep
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamLeaveUseCase
 import com.studentcenter.weave.application.meetingTeam.service.domain.impl.MeetingTeamDomainServiceImpl
-import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingMember
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.enums.MeetingMemberRole
@@ -41,12 +41,7 @@ class MeetingTeamLeaveApplicationServiceTest : DescribeSpec({
                 // arrange
                 val meetingTeam = MeetingTeamFixtureFactory.create()
                 val user = UserFixtureFactory.create()
-                val userAuthentication = UserAuthentication(
-                    userId = user.id,
-                    email = user.email,
-                    nickname = user.nickname,
-                    avatar = null,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(user)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                 val meetingMember = MeetingMember.create(
@@ -73,12 +68,7 @@ class MeetingTeamLeaveApplicationServiceTest : DescribeSpec({
                 // arrange
                 val meetingTeam = MeetingTeamFixtureFactory.create()
                 val user = UserFixtureFactory.create()
-                val userAuthentication = UserAuthentication(
-                    userId = user.id,
-                    email = user.email,
-                    nickname = user.nickname,
-                    avatar = null,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(user)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
                 meetingTeamRepository.save(meetingTeam)
 
@@ -95,12 +85,7 @@ class MeetingTeamLeaveApplicationServiceTest : DescribeSpec({
                 // arrange
                 val meetingTeam = MeetingTeamFixtureFactory.create()
                 val user = UserFixtureFactory.create()
-                val userAuthentication = UserAuthentication(
-                    userId = user.id,
-                    email = user.email,
-                    nickname = user.nickname,
-                    avatar = null,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(user)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                 val meetingMember = MeetingMember.create(

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserGetMyProfileApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserGetMyProfileApplicationServiceTest.kt
@@ -11,6 +11,7 @@ import com.studentcenter.weave.application.user.port.outbound.UserSilRepositoryS
 import com.studentcenter.weave.application.user.service.domain.impl.UserDomainServiceImpl
 import com.studentcenter.weave.application.user.service.domain.impl.UserSilDomainServiceImpl
 import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.user.entity.MajorFixtureFactory
 import com.studentcenter.weave.domain.user.entity.UniversityFixtureFactory
 import com.studentcenter.weave.domain.user.entity.User
@@ -56,12 +57,7 @@ class UserGetMyProfileApplicationServiceTest : DescribeSpec({
             it("사용자의 프로필 정보를 응답한다.") {
                 // arrange
                 val user: User = UserFixtureFactory.create()
-                val userAuthentication = UserAuthentication(
-                    userId = user.id,
-                    nickname = user.nickname,
-                    email = user.email,
-                    avatar = user.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(user)
                 val userSecurityContext = UserSecurityContext(userAuthentication)
                 SecurityContextHolder.setContext(userSecurityContext)
                 userRepositorySpy.save(user)

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserLogoutApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserLogoutApplicationServiceTest.kt
@@ -3,6 +3,7 @@ package com.studentcenter.weave.application.user.service.application
 import com.studentcenter.weave.application.common.security.context.UserSecurityContext
 import com.studentcenter.weave.application.user.port.outbound.UserRefreshTokenRepositorySpy
 import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.user.entity.User
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
 import com.studentcenter.weave.support.security.context.SecurityContextHolder
@@ -25,12 +26,7 @@ class UserLogoutApplicationServiceTest : DescribeSpec({
         it("저장된 갱신 토큰을 삭제한다") {
             // arrange
             val user: User = UserFixtureFactory.create()
-            val userAuthentication = UserAuthentication(
-                userId = user.id,
-                email = user.email,
-                nickname = user.nickname,
-                avatar = user.avatar
-            )
+            val userAuthentication = UserAuthenticationFixtureFactory.create(user)
             userRefreshTokenRepositorySpy.save(
                 userId = user.id,
                 refreshToken = "refreshToken",

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserModifyMyMbtiApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserModifyMyMbtiApplicationServiceTest.kt
@@ -4,6 +4,7 @@ import com.studentcenter.weave.application.common.security.context.UserSecurityC
 import com.studentcenter.weave.application.user.port.outbound.UserRepositorySpy
 import com.studentcenter.weave.application.user.service.domain.impl.UserDomainServiceImpl
 import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
 import com.studentcenter.weave.domain.user.vo.Mbti
 import com.studentcenter.weave.support.security.context.SecurityContextHolder
@@ -26,12 +27,7 @@ class UserModifyMyMbtiApplicationServiceTest : DescribeSpec({
                 val user = UserFixtureFactory.create()
                 userRepositorySpy.save(user)
 
-                val userAuthentication = UserAuthentication(
-                    userId = user.id,
-                    email = user.email,
-                    nickname = user.nickname,
-                    avatar = user.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(user)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                 // act

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserSendVerificationNumberEmailApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserSendVerificationNumberEmailApplicationServiceTest.kt
@@ -6,6 +6,7 @@ import com.studentcenter.weave.application.user.port.outbound.UserVerificationNu
 import com.studentcenter.weave.application.user.port.outbound.VerificationNumberMailer
 import com.studentcenter.weave.application.user.service.domain.impl.UserUniversityVerificationInfoDomainServiceImpl
 import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
 import com.studentcenter.weave.domain.user.entity.UserUniversityVerificationInfoFixtureFactory
 import com.studentcenter.weave.support.common.exception.CustomException
@@ -45,12 +46,7 @@ class UserSendVerificationNumberEmailApplicationServiceTest : DescribeSpec({
             it("인증 번호 전송 요청을 하면 인증 번호 전송, 저장한다.") {
                 // arrange
                 val userFixture = UserFixtureFactory.create()
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    nickname = userFixture.nickname,
-                    email = userFixture.email,
-                    avatar = userFixture.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
                 val email = Email("weave@studentcenter.com")
 
@@ -70,12 +66,7 @@ class UserSendVerificationNumberEmailApplicationServiceTest : DescribeSpec({
             it("전송 요청을 하면 인증 번호 전송 및 저장을 한다.") {
                 // arrange
                 val userFixture = UserFixtureFactory.create()
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    nickname = userFixture.nickname,
-                    email = userFixture.email,
-                    avatar = userFixture.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
                 sut.invoke(Email("weave@studentcenter.com"))
                 val (existEmail, existVerificationNumber) = userVerificationNumberRepository
@@ -100,12 +91,7 @@ class UserSendVerificationNumberEmailApplicationServiceTest : DescribeSpec({
             it("예외를 던진다") {
                 // arrange
                 val userFixture = UserFixtureFactory.create()
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    nickname = userFixture.nickname,
-                    email = userFixture.email,
-                    avatar = userFixture.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
                 val email = Email("re-weave@studentcenter.com")
                 val verificationInfo = UserUniversityVerificationInfoFixtureFactory.create(

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserSetMyAnimalTypeApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserSetMyAnimalTypeApplicationServiceTest.kt
@@ -6,6 +6,7 @@ import com.studentcenter.weave.application.user.port.outbound.UserSilRepositoryS
 import com.studentcenter.weave.application.user.service.domain.impl.UserDomainServiceImpl
 import com.studentcenter.weave.application.user.service.domain.impl.UserSilDomainServiceImpl
 import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.user.entity.User
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
 import com.studentcenter.weave.domain.user.entity.UserSil
@@ -42,12 +43,7 @@ class UserSetMyAnimalTypeApplicationServiceTest : DescribeSpec({
                     userRepositorySpy.save(userFixture)
                     userSilRepositorySpy.save(UserSil.create(userFixture.id))
 
-                    val userAuthentication = UserAuthentication(
-                        userId = userFixture.id,
-                        email = userFixture.email,
-                        nickname = userFixture.nickname,
-                        avatar = userFixture.avatar
-                    )
+                    val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                     SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                     // act
@@ -68,12 +64,7 @@ class UserSetMyAnimalTypeApplicationServiceTest : DescribeSpec({
                 userRepositorySpy.save(userFixture)
                 userSilRepositorySpy.save(UserSil.create(userFixture.id))
 
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    email = userFixture.email,
-                    nickname = userFixture.nickname,
-                    avatar = userFixture.avatar
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                 // act
@@ -92,12 +83,7 @@ class UserSetMyAnimalTypeApplicationServiceTest : DescribeSpec({
                 userRepositorySpy.save(userFixture)
                 userSilRepositorySpy.save(UserSil.create(userFixture.id))
 
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    email = userFixture.email,
-                    nickname = userFixture.nickname,
-                    avatar = userFixture.avatar
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                 // act

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserSetMyHeightApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserSetMyHeightApplicationServiceTest.kt
@@ -6,6 +6,7 @@ import com.studentcenter.weave.application.user.port.outbound.UserSilRepositoryS
 import com.studentcenter.weave.application.user.service.domain.impl.UserDomainServiceImpl
 import com.studentcenter.weave.application.user.service.domain.impl.UserSilDomainServiceImpl
 import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.user.entity.User
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
 import com.studentcenter.weave.domain.user.entity.UserSil
@@ -43,12 +44,7 @@ class UserSetMyHeightApplicationServiceTest : DescribeSpec({
                 userRepositorySpy.save(userFixture)
                 userSilRepositorySpy.save(UserSil.create(userFixture.id))
 
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    nickname = userFixture.nickname,
-                    email = userFixture.email,
-                    avatar = userFixture.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                 // act
@@ -68,12 +64,7 @@ class UserSetMyHeightApplicationServiceTest : DescribeSpec({
                 userRepositorySpy.save(userFixture)
                 userSilRepositorySpy.save(UserSil.create(userFixture.id))
 
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    nickname = userFixture.nickname,
-                    email = userFixture.email,
-                    avatar = userFixture.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                 // act
@@ -93,12 +84,7 @@ class UserSetMyHeightApplicationServiceTest : DescribeSpec({
                 userRepositorySpy.save(userFixture)
                 userSilRepositorySpy.save(UserSil.create(userFixture.id))
 
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    nickname = userFixture.nickname,
-                    email = userFixture.email,
-                    avatar = userFixture.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
 
                 // act

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserUnregisterApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserUnregisterApplicationServiceTest.kt
@@ -10,6 +10,7 @@ import com.studentcenter.weave.application.user.service.domain.impl.DeletedUserI
 import com.studentcenter.weave.application.user.service.domain.impl.UserAuthInfoDomainServiceImpl
 import com.studentcenter.weave.application.user.service.domain.impl.UserDomainServiceImpl
 import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.user.entity.User
 import com.studentcenter.weave.domain.user.entity.UserAuthInfo
 import com.studentcenter.weave.domain.user.entity.UserAuthInfoFixtureFactory
@@ -55,12 +56,7 @@ class UserUnregisterApplicationServiceTest : DescribeSpec({
                 userRepositorySpy.save(user)
                 userAuthInfoRepositorySpy.save(userAuth)
 
-                val loginAuthentication = UserAuthentication(
-                    userId = user.id,
-                    email = user.email,
-                    nickname = user.nickname,
-                    avatar = user.avatar,
-                )
+                val loginAuthentication = UserAuthenticationFixtureFactory.create(user)
                 SecurityContextHolder.setContext(UserSecurityContext(loginAuthentication))
 
                 val command = UserUnregisterUseCase.Command()

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserVerifyVerificationNumberApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/application/UserVerifyVerificationNumberApplicationServiceTest.kt
@@ -11,6 +11,7 @@ import com.studentcenter.weave.application.user.service.domain.impl.UserDomainSe
 import com.studentcenter.weave.application.user.service.domain.impl.UserSilDomainServiceImpl
 import com.studentcenter.weave.application.user.service.domain.impl.UserUniversityVerificationInfoDomainServiceImpl
 import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.application.user.vo.UserUniversityVerificationNumber
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
 import com.studentcenter.weave.domain.user.entity.UserUniversityVerificationInfoFixtureFactory
@@ -66,12 +67,7 @@ class UserVerifyVerificationNumberApplicationServiceTest : DescribeSpec({
             it("예외를 던진다.") {
                 // arrange
                 val userFixture = UserFixtureFactory.create()
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    nickname = userFixture.nickname,
-                    email = userFixture.email,
-                    avatar = userFixture.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
                 userSendVerificationNumberEmailApplicationService.invoke(Email("weave@studentcenter.com"))
                 val verificationNumber = userVerificationNumberRepository.findByUserId(userFixture.id)!!.second
@@ -87,12 +83,7 @@ class UserVerifyVerificationNumberApplicationServiceTest : DescribeSpec({
             it("예외를 던진다.") {
                 // arrange
                 val userFixture = UserFixtureFactory.create()
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    nickname = userFixture.nickname,
-                    email = userFixture.email,
-                    avatar = userFixture.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
                 val email = Email("weave@studentcenter.com")
                 userSendVerificationNumberEmailApplicationService.invoke(email)
@@ -114,12 +105,7 @@ class UserVerifyVerificationNumberApplicationServiceTest : DescribeSpec({
             it("예외를 던진다.") {
                 // arrange
                 val userFixture = UserFixtureFactory.create()
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    nickname = userFixture.nickname,
-                    email = userFixture.email,
-                    avatar = userFixture.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
                 val email = Email("weave@studentcenter.com")
                 val verificationNumber = UserUniversityVerificationNumber.generate()
@@ -134,12 +120,7 @@ class UserVerifyVerificationNumberApplicationServiceTest : DescribeSpec({
             it("예외를 던진다.") {
                 // arrange
                 val userFixture = UserFixtureFactory.create()
-                val userAuthentication = UserAuthentication(
-                    userId = userFixture.id,
-                    nickname = userFixture.nickname,
-                    email = userFixture.email,
-                    avatar = userFixture.avatar,
-                )
+                val userAuthentication = UserAuthenticationFixtureFactory.create(userFixture)
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
                 val verificationInfo = UserUniversityVerificationInfoFixtureFactory.create(
                     user = userFixture
@@ -174,6 +155,7 @@ class UserVerifyVerificationNumberApplicationServiceTest : DescribeSpec({
                     nickname = user.nickname,
                     email = user.email,
                     avatar = user.avatar,
+                    gender = user.gender
                 )
                 SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
                 val email = Email("weave@studentcenter.com")
@@ -190,7 +172,6 @@ class UserVerifyVerificationNumberApplicationServiceTest : DescribeSpec({
                 userSilRepository.getByUserId(user.id).amount shouldBeGreaterThan 0
             }
         }
-
     }
 
 })

--- a/application/src/test/kotlin/com/studentcenter/weave/application/user/service/util/impl/UserTokenServiceImplTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/user/service/util/impl/UserTokenServiceImplTest.kt
@@ -115,6 +115,7 @@ class UserTokenServiceImplTest : DescribeSpec({
                 nickname = user.nickname,
                 email = user.email,
                 avatar = user.avatar,
+                gender = user.gender,
             )
         }
 

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/user/vo/UserAuthenticationFixtureFactory.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/user/vo/UserAuthenticationFixtureFactory.kt
@@ -1,0 +1,17 @@
+package com.studentcenter.weave.application.user.vo
+
+import com.studentcenter.weave.domain.user.entity.User
+
+object UserAuthenticationFixtureFactory {
+
+    fun create(user: User) : UserAuthentication {
+        return UserAuthentication(
+            userId = user.id,
+            nickname = user.nickname,
+            email = user.email,
+            avatar = user.avatar,
+            gender = user.gender,
+        )
+    }
+
+}

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/user/vo/UserTokenClaimsFixtureFactory.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/user/vo/UserTokenClaimsFixtureFactory.kt
@@ -12,7 +12,8 @@ object UserTokenClaimsFixtureFactory {
             userId = user.id,
             email = user.email,
             nickname = user.nickname,
-            avatar = user.avatar
+            avatar = user.avatar,
+            gender = user.gender,
         )
     }
 


### PR DESCRIPTION
## 배경
- 미팅팀 목록조회시 회원의 gender를 확인하고 반대되는 성별의 미팅팀을 조회해야하는데, 이때 현재 유저의 성별 정보가 필요해요.
- 매번 DB에서 조회하기 보다 token claim으로 성별을 가지고 있으면, DB부하를 줄이면서 처리하기 용이하다 생각해서 access token에 gender를 추가했어요

## 구현사항
- Access Token Claim에 Gender를 추가했어요
- claim추가에 따른 테스트 수정사항이 있었어요.
  - 이후에도 token claim수정에 따른 테스트 수정이 많이 전파되지 않도록 UserAuthenticationFxitureFactory를 구현해 적용했어요