### PR TITLE
[WEAV-234] 미팅팀 공개 로직 구현

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/outbound/MeetingTeamMemberSummaryRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/outbound/MeetingTeamMemberSummaryRepository.kt
@@ -1,0 +1,16 @@
+package com.studentcenter.weave.application.meetingTeam.port.outbound
+
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamMemberSummary
+import java.util.*
+
+interface MeetingTeamMemberSummaryRepository {
+
+    fun save(meetingTeamMemberSummary: MeetingTeamMemberSummary)
+
+    fun deleteById(id: UUID)
+
+    fun getById(id: UUID): MeetingTeamMemberSummary
+
+    fun getByMeetingTeamId(meetingTeamId: UUID): MeetingTeamMemberSummary
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/MeetingTeamDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/MeetingTeamDomainService.kt
@@ -32,6 +32,8 @@ interface MeetingTeamDomainService {
         teamId: UUID
     )
 
+    fun publishById(id: UUID): MeetingTeam
+
     fun getById(id: UUID): MeetingTeam
 
     fun scrollByMemberUserId(

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImpl.kt
@@ -124,13 +124,15 @@ class MeetingTeamDomainServiceImpl(
 
     @Transactional
     override fun publishById(id: UUID): MeetingTeam {
-        return meetingTeamRepository
-            .getById(id)
-            .publish()
-            .also {
-                meetingTeamRepository.save(it)
-                meetingTeamMemberSummaryRepository.save(createMeetingTeamMemberSummary(it))
-            }
+        val meetingTeam = meetingTeamRepository.getById(id)
+        return if(meetingTeam.isPublished()) {
+            meetingTeam
+        } else {
+            createMeetingTeamMemberSummary(meetingTeam)
+                .also { meetingTeamMemberSummaryRepository.save(it) }
+                .let { meetingTeam.publish() }
+                .also { meetingTeamRepository.save(it) }
+        }
     }
 
     @Transactional

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateApplicationServiceTest.kt
@@ -2,12 +2,12 @@ package com.studentcenter.weave.application.meetingTeam.service.application
 
 import com.studentcenter.weave.application.common.security.context.UserSecurityContext
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingMemberRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamMemberSummaryRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamCreateUseCase
 import com.studentcenter.weave.application.meetingTeam.service.domain.impl.MeetingTeamDomainServiceImpl
 import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCaseStub
 import com.studentcenter.weave.application.user.port.outbound.UserRepositorySpy
-import com.studentcenter.weave.application.user.vo.UserAuthentication
 import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.enums.Location
 import com.studentcenter.weave.domain.meetingTeam.vo.TeamIntroduce
@@ -18,15 +18,20 @@ import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.mockk.mockk
 
 @DisplayName("MeetingTeamCreateApplicationServiceTest")
 class MeetingTeamCreateApplicationServiceTest : DescribeSpec({
 
     val meetingTeamRepositorySpy = MeetingTeamRepositorySpy()
     val meetingMemberRepositorySpy = MeetingMemberRepositorySpy()
+    val meetingTeamMemberSummaryRepositorySpy = MeetingTeamMemberSummaryRepositorySpy()
+    val userQueryUseCaseMock = mockk<UserQueryUseCaseStub>()
     val meetingTeamDomainService = MeetingTeamDomainServiceImpl(
         meetingTeamRepositorySpy,
         meetingMemberRepositorySpy,
+        meetingTeamMemberSummaryRepositorySpy,
+        userQueryUseCaseMock,
     )
 
     val userRepositorySpy = UserRepositorySpy()

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamDeleteApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamDeleteApplicationServiceTest.kt
@@ -1,15 +1,18 @@
 package com.studentcenter.weave.application.meetingTeam.service.application
 
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingMemberRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamMemberSummaryRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamDeleteUseCase
 import com.studentcenter.weave.application.meetingTeam.service.domain.impl.MeetingTeamDomainServiceImpl
+import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCase
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingMember
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.enums.MeetingMemberRole
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.mockk
 import org.springframework.stereotype.Service
 
 @Service("meetingTeamDeleteApplicationService")
@@ -17,9 +20,14 @@ class MeetingTeamDeleteApplicationServiceTest : DescribeSpec({
 
     val meetingTeamRepository = MeetingTeamRepositorySpy()
     val meetingMemberRepository = MeetingMemberRepositorySpy()
+    val meetingTeamMemberSummaryRepository = MeetingTeamMemberSummaryRepositorySpy()
+    val userQueryUseCase = mockk<UserQueryUseCase>()
+
     val meetingTeamDomainService = MeetingTeamDomainServiceImpl(
         meetingTeamRepository,
         meetingMemberRepository,
+        meetingTeamMemberSummaryRepository,
+        userQueryUseCase,
     )
     val sut = MeetingTeamDeleteApplicationService(meetingTeamDomainService)
 

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamEditApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamEditApplicationServiceTest.kt
@@ -2,10 +2,11 @@ package com.studentcenter.weave.application.meetingTeam.service.application
 
 import com.studentcenter.weave.application.common.security.context.UserSecurityContext
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingMemberRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamMemberSummaryRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamEditUseCase
 import com.studentcenter.weave.application.meetingTeam.service.domain.impl.MeetingTeamDomainServiceImpl
-import com.studentcenter.weave.application.user.vo.UserAuthentication
+import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCase
 import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingMember
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
@@ -18,15 +19,21 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.mockk
 
 @DisplayName("MeetingTeamEditApplicationService")
 class MeetingTeamEditApplicationServiceTest : DescribeSpec({
 
     val meetingTeamRepository = MeetingTeamRepositorySpy()
     val meetingMemberRepository = MeetingMemberRepositorySpy()
+    val meetingTeamMemberSummaryRepository = MeetingTeamMemberSummaryRepositorySpy()
+    val userQueryUseCase = mockk<UserQueryUseCase>()
+
     val meetingTeamDomainService = MeetingTeamDomainServiceImpl(
         meetingTeamRepository = meetingTeamRepository,
-        meetingMemberRepository = meetingMemberRepository
+        meetingMemberRepository = meetingMemberRepository,
+        meetingTeamMemberSummaryRepository = meetingTeamMemberSummaryRepository,
+        userQueryUseCase = userQueryUseCase,
     )
     val sut = MeetingTeamEditApplicationService(
         meetingTeamDomainService = meetingTeamDomainService

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationServiceTest.kt
@@ -3,9 +3,11 @@ package com.studentcenter.weave.application.meetingTeam.service.application
 import com.studentcenter.weave.application.common.exception.MeetingTeamExceptionType
 import com.studentcenter.weave.application.common.security.context.UserSecurityContext
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingMemberRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamMemberSummaryRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamLeaveUseCase
 import com.studentcenter.weave.application.meetingTeam.service.domain.impl.MeetingTeamDomainServiceImpl
+import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCase
 import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingMember
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
@@ -17,15 +19,20 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.mockk
 
 @DisplayName("MeetingTeamLeaveApplicationService")
 class MeetingTeamLeaveApplicationServiceTest : DescribeSpec({
 
     val meetingMemberRepository = MeetingMemberRepositorySpy()
     val meetingTeamRepository = MeetingTeamRepositorySpy()
+    val meetingTeamMemberSummaryRepository = MeetingTeamMemberSummaryRepositorySpy()
+    val userQueryUseCase = mockk<UserQueryUseCase>()
     val meetingTeamDomainService = MeetingTeamDomainServiceImpl(
         meetingMemberRepository = meetingMemberRepository,
-        meetingTeamRepository = meetingTeamRepository
+        meetingTeamRepository = meetingTeamRepository,
+        meetingTeamMemberSummaryRepository = meetingTeamMemberSummaryRepository,
+        userQueryUseCase = userQueryUseCase,
     )
     val sut = MeetingTeamLeaveApplicationService(meetingTeamDomainService)
 

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
@@ -123,20 +123,6 @@ class MeetingTeamDomainServiceImplTest : DescribeSpec({
     }
 
     describe("publish") {
-        context("미팅 팀에 소속된 멤버 수가 0일 경우") {
-            it("예외를 발생시킨다.") {
-                // arrange
-                val meetingTeam = MeetingTeamFixtureFactory.create()
-                every { userQueryUseCase.getById(any()) } returns UserFixtureFactory.create()
-                meetingTeamRepositorySpy.save(meetingTeam)
-
-                // act, assert
-                shouldThrow<IllegalArgumentException> {
-                    sut.publishById(meetingTeam.id)
-                }
-            }
-        }
-
         context("미팅 팀에 소속된 멤버 수가 설정된 멤버수와 동일할 경우") {
             it("팀 멤버 요약정보를 생성하고, 미팅 팀을 공개한다.") {
                 // arrange

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
@@ -198,6 +198,41 @@ class MeetingTeamDomainServiceImplTest : DescribeSpec({
                 }
             }
         }
+
+        context("미팅팀이 이미 공개된 상태인 경우") {
+            it("미팅팀을 반환한다") {
+                // arrange
+                val memberCount = 2
+                val meetingTeam = MeetingTeamFixtureFactory.create(memberCount = memberCount)
+                val user1 = UserFixtureFactory.create()
+                val user2 = UserFixtureFactory.create()
+                val meetingMember1 = MeetingMember.create(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user1.id,
+                    role = MeetingMemberRole.LEADER
+                )
+                val meetingMember2 = MeetingMember.create(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user2.id,
+                    role = MeetingMemberRole.MEMBER
+                )
+
+                every { userQueryUseCase.getById(user1.id) } returns user1
+                every { userQueryUseCase.getById(user2.id) } returns user2
+
+                meetingMemberRepositorySpy.save(meetingMember1)
+                meetingMemberRepositorySpy.save(meetingMember2)
+                meetingTeamRepositorySpy.save(meetingTeam)
+
+                sut.publishById(meetingTeam.id)
+
+                // act
+                val result: MeetingTeam = sut.publishById(meetingTeam.id)
+
+                // assert
+                result.isPublished() shouldBe true
+            }
+        }
     }
 
 })

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
@@ -175,6 +175,29 @@ class MeetingTeamDomainServiceImplTest : DescribeSpec({
                 }
             }
         }
+
+        context("미팅팀에 소속된 멤버 수가 설정된 멤버수보다 작을 경우") {
+            it("예외를 발생시킨다.") {
+                // arrange
+                val memberCount = 2
+                val meetingTeam = MeetingTeamFixtureFactory.create(memberCount = memberCount)
+                val user = UserFixtureFactory.create()
+                val meetingMember = MeetingMember.create(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user.id,
+                    role = MeetingMemberRole.LEADER
+                )
+
+                every { userQueryUseCase.getById(user.id) } returns user
+                meetingMemberRepositorySpy.save(meetingMember)
+                meetingTeamRepositorySpy.save(meetingTeam)
+
+                // act, assert
+                shouldThrow<IllegalArgumentException> {
+                    sut.publishById(meetingTeam.id)
+                }
+            }
+        }
     }
 
 })

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/impl/MeetingTeamDomainServiceImplTest.kt
@@ -1,24 +1,35 @@
 package com.studentcenter.weave.application.meetingTeam.service.domain.impl
 
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingMemberRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamMemberSummaryRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamRepositorySpy
+import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCase
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingMember
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeam
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.enums.MeetingMemberRole
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
 
 @DisplayName("MeetingTeamDomainServiceImpl")
 class MeetingTeamDomainServiceImplTest : DescribeSpec({
 
     val meetingTeamRepositorySpy = MeetingTeamRepositorySpy()
     val meetingMemberRepositorySpy = MeetingMemberRepositorySpy()
+    val meetingTeamMemberSummaryRepositorySpy = MeetingTeamMemberSummaryRepositorySpy()
+    val userQueryUseCase = mockk<UserQueryUseCase>()
+
     val sut = MeetingTeamDomainServiceImpl(
         meetingTeamRepository = meetingTeamRepositorySpy,
         meetingMemberRepository = meetingMemberRepositorySpy,
+        meetingTeamMemberSummaryRepository = meetingTeamMemberSummaryRepositorySpy,
+        userQueryUseCase = userQueryUseCase,
     )
 
     afterEach {
@@ -107,6 +118,61 @@ class MeetingTeamDomainServiceImplTest : DescribeSpec({
 
                 // assert
                 result shouldBe meetingMember
+            }
+        }
+    }
+
+    describe("publish") {
+        context("미팅 팀에 소속된 멤버 수가 0일 경우") {
+            it("예외를 발생시킨다.") {
+                // arrange
+                val meetingTeam = MeetingTeamFixtureFactory.create()
+                every { userQueryUseCase.getById(any()) } returns UserFixtureFactory.create()
+                meetingTeamRepositorySpy.save(meetingTeam)
+
+                // act, assert
+                shouldThrow<IllegalArgumentException> {
+                    sut.publishById(meetingTeam.id)
+                }
+            }
+        }
+
+        context("미팅 팀에 소속된 멤버 수가 설정된 멤버수와 동일할 경우") {
+            it("팀 멤버 요약정보를 생성하고, 미팅 팀을 공개한다.") {
+                // arrange
+                val memberCount = 2
+                val meetingTeam = MeetingTeamFixtureFactory.create(memberCount = memberCount)
+                val user1 = UserFixtureFactory.create()
+                val user2 = UserFixtureFactory.create()
+                val meetingMember1 = MeetingMember.create(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user1.id,
+                    role = MeetingMemberRole.LEADER
+                )
+                val meetingMember2 = MeetingMember.create(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user2.id,
+                    role = MeetingMemberRole.MEMBER
+                )
+
+                every { userQueryUseCase.getById(user1.id) } returns user1
+                every { userQueryUseCase.getById(user2.id) } returns user2
+
+                meetingMemberRepositorySpy.save(meetingMember1)
+                meetingMemberRepositorySpy.save(meetingMember2)
+                meetingTeamRepositorySpy.save(meetingTeam)
+
+                // act
+                val result: MeetingTeam = sut.publishById(meetingTeam.id)
+
+                // assert
+                result.isPublished() shouldBe true
+                meetingTeamRepositorySpy.getById(meetingTeam.id).isPublished() shouldBe true
+                shouldNotThrowAny {
+                    meetingTeamMemberSummaryRepositorySpy.getByMeetingTeamId(
+                        meetingTeam.id
+                    )
+                }
             }
         }
     }

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/outbound/MeetingTeamMemberSummaryRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/outbound/MeetingTeamMemberSummaryRepositorySpy.kt
@@ -1,0 +1,29 @@
+package com.studentcenter.weave.application.meetingTeam.outbound
+
+import com.studentcenter.weave.application.meetingTeam.port.outbound.MeetingTeamMemberSummaryRepository
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamMemberSummary
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+class MeetingTeamMemberSummaryRepositorySpy : MeetingTeamMemberSummaryRepository {
+
+    private val bucket = ConcurrentHashMap<UUID, MeetingTeamMemberSummary>()
+
+    override fun save(meetingTeamMemberSummary: MeetingTeamMemberSummary) {
+        bucket[meetingTeamMemberSummary.id] = meetingTeamMemberSummary
+    }
+
+    override fun deleteById(id: UUID) {
+        bucket.remove(id)
+    }
+
+    override fun getById(id: UUID): MeetingTeamMemberSummary {
+        return bucket[id] ?: throw NoSuchElementException()
+    }
+
+    override fun getByMeetingTeamId(meetingTeamId: UUID): MeetingTeamMemberSummary {
+        return bucket.values.find { it.meetingTeamId == meetingTeamId }
+            ?: throw NoSuchElementException()
+    }
+
+}

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeam.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeam.kt
@@ -34,6 +34,14 @@ data class MeetingTeam(
         )
     }
 
+    fun publish(): MeetingTeam {
+        return copy(status = MeetingTeamStatus.PUBLISHED)
+    }
+
+    fun isPublished(): Boolean {
+        return status == MeetingTeamStatus.PUBLISHED
+    }
+
     companion object {
 
         fun create(

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
@@ -1,5 +1,6 @@
 package com.studentcenter.weave.domain.meetingTeam.entity
 
+import com.studentcenter.weave.domain.user.entity.User
 import com.studentcenter.weave.domain.user.vo.BirthYear
 import com.studentcenter.weave.domain.user.vo.Mbti
 import com.studentcenter.weave.support.common.uuid.UuidCreator
@@ -18,6 +19,43 @@ data class MeetingTeamMemberSummary(
     init {
         require(youngestMemberBirthYear.value >= oldestMemberBirthYear.value) {
             "가장 나이가 어린 멤버의 년생은 가장 나이가 많은 멤버의 년생보다 작아야 합니다."
+        }
+    }
+
+    companion object {
+
+        fun create(
+            meetingTeamId: UUID,
+            members: List<User>
+        ): MeetingTeamMemberSummary {
+            require(members.isNotEmpty()) {
+                "팀에 속한 멤버가 존재해야 합니다."
+            }
+            return MeetingTeamMemberSummary(
+                meetingTeamId = meetingTeamId,
+                teamMbti = getTeamMbti(members),
+                youngestMemberBirthYear = getYoungestMemberBirthYear(members),
+                oldestMemberBirthYear = getOldestMemberBirthYear(members)
+            )
+        }
+
+        private fun getTeamMbti(members: List<User>): Mbti {
+            return members
+                .map { it.mbti }
+                .toList()
+                .let { Mbti.getDominantMbti(it) }
+        }
+
+        private fun getYoungestMemberBirthYear(members: List<User>): BirthYear {
+            return members
+                .map { it.birthYear }
+                .minBy { it.value }
+        }
+
+        private fun getOldestMemberBirthYear(members: List<User>): BirthYear {
+            return members
+                .map { it.birthYear }
+                .maxBy { it.value }
         }
     }
 

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/adapter/MeetingTeamMemberSummaryJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/adapter/MeetingTeamMemberSummaryJpaAdapter.kt
@@ -1,0 +1,44 @@
+package com.studentcenter.weave.infrastructure.persistence.meetingTeam.adapter
+
+import com.studentcenter.weave.application.meetingTeam.port.outbound.MeetingTeamMemberSummaryRepository
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamMemberSummary
+import com.studentcenter.weave.infrastructure.persistence.common.exception.PersistenceExceptionType
+import com.studentcenter.weave.infrastructure.persistence.meetingTeam.repository.MeetingTeamMemberSummaryJpaRepository
+import com.studentcenter.weave.support.common.exception.CustomException
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class MeetingTeamMemberSummaryJpaAdapter(
+    private val meetingTeamMemberSummaryJpaRepository: MeetingTeamMemberSummaryJpaRepository
+) : MeetingTeamMemberSummaryRepository {
+
+    override fun save(meetingTeamMemberSummary: MeetingTeamMemberSummary) {
+        meetingTeamMemberSummaryJpaRepository.save(meetingTeamMemberSummary)
+    }
+
+    override fun deleteById(id: UUID) {
+        meetingTeamMemberSummaryJpaRepository.deleteById(id)
+    }
+
+    override fun getById(id: UUID): MeetingTeamMemberSummary {
+        return meetingTeamMemberSummaryJpaRepository
+            .findById(id)
+            .orElseThrow {
+                CustomException(
+                    type = PersistenceExceptionType.RESOURCE_NOT_FOUND,
+                    message = "MeetingTeamMemberSummary(id=$id)를 찾을 수 없습니다."
+                )
+            }
+    }
+
+    override fun getByMeetingTeamId(meetingTeamId: UUID): MeetingTeamMemberSummary {
+        return meetingTeamMemberSummaryJpaRepository
+            .findByMeetingTeamId(meetingTeamId)
+            ?: throw CustomException(
+                type = PersistenceExceptionType.RESOURCE_NOT_FOUND,
+                message = "MeetingTeamMemberSummary(meetingTeamId=$meetingTeamId)를 찾을 수 없습니다."
+            )
+    }
+
+}

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/repository/MeetingTeamMemberSummaryJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/repository/MeetingTeamMemberSummaryJpaRepository.kt
@@ -1,0 +1,11 @@
+package com.studentcenter.weave.infrastructure.persistence.meetingTeam.repository
+
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamMemberSummary
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface MeetingTeamMemberSummaryJpaRepository : JpaRepository<MeetingTeamMemberSummary, UUID> {
+
+    fun findByMeetingTeamId(meetingTeamId: UUID): MeetingTeamMemberSummary?
+
+}


### PR DESCRIPTION
## 구현사항

- 미팅팀의 멤버가 모두 초대 되면, 팀을 공개하기위해 호출할 수 있는 publish 메서드를 작성했어요.
  - 미팅팀에 참여한 멤버가 설정된 팀 인원수보다 적은 경우 -> 예외
  - 미팅팀이 이미 공개된 상태인 경우 -> 미팅팀 반환(멱등)
  - 미팅팀에 참여한 멤버가 설정된 팀 인원수와 같고, 공개된 상태가 아닌경우 -> 멤버 요약정보 생성 및 공개 상태로 변경

## 추가 논의 사항 (추후 리팩토링 제안)

- 현재 메서드의 경우 미팅팀에 초대된 멤버가 모두 가입하면 호출해야 하는 메서드인데요, 이경우 메서드 사용자 측에서 어떤 메서드들을 호출해야하는지 알고 직접적으로 호출해야 하는 강하게 결합된 상태로 보여요. (미팅 팀원 초대 구현에서 반영해야함)
- 이렇게 하지 말고, 모든 멤버가 초대되었다 라는 이벤트를 발행하면, 해당 event를 consume하는 측에서 어떤 메서드들을 호출해야하는지만 알면  좀더 유연하게 처리 가능할것 같은데, 어떻게 생각하시나요?
- Spring 자체 message queue를 활용하면 공수가 크게 들어가지는 않을것 같아요
- 이러한 구현을 위해서는 inbound를 다음과 같이 분리해야 할것같아요.
  - 사용자의 도메인 조작 요청(UseCase), 타 도메인의 조작요청(EventHandler), 쿼리(QueryHandler)