### PR TITLE
[WEAV-199] 미팅 팀 초대 링크 생성 API

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/common/properties/MeetingTeamInvitationProperties.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/common/properties/MeetingTeamInvitationProperties.kt
@@ -1,0 +1,10 @@
+package com.studentcenter.weave.application.common.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import kotlin.time.Duration
+
+@ConfigurationProperties(value = "meeting.team.invitation")
+data class MeetingTeamInvitationProperties(
+    val urlPrefix: String,
+    val expireSeconds: Duration,
+)

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/inbound/MeetingTeamCreateInvitationUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/inbound/MeetingTeamCreateInvitationUseCase.kt
@@ -1,0 +1,13 @@
+package com.studentcenter.weave.application.meetingTeam.port.inbound
+
+import java.util.*
+
+fun interface MeetingTeamCreateInvitationUseCase {
+
+    fun invoke(meetingTeamId: UUID): Result
+
+    data class Result(
+        val invitationLink: String,
+    )
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/outbound/MeetingTeamInvitationRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/outbound/MeetingTeamInvitationRepository.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.application.meetingTeam.port.outbound
+
+import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInvitation
+
+interface MeetingTeamInvitationRepository {
+
+    fun save(meetingTeamInvitation: MeetingTeamInvitation)
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateInvitationApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateInvitationApplicationService.kt
@@ -1,0 +1,76 @@
+package com.studentcenter.weave.application.meetingTeam.service.application
+
+import com.studentcenter.weave.application.common.security.context.getCurrentUserAuthentication
+import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamCreateInvitationUseCase
+import com.studentcenter.weave.application.meetingTeam.service.domain.MeetingTeamDomainService
+import com.studentcenter.weave.application.meetingTeam.util.MeetingTeamInvitationService
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeam
+import com.studentcenter.weave.domain.meetingTeam.enums.MeetingTeamStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+class MeetingTeamCreateInvitationApplicationService(
+    private val meetingTeamInvitationService: MeetingTeamInvitationService,
+    private val meetingTeamDomainService: MeetingTeamDomainService,
+) : MeetingTeamCreateInvitationUseCase {
+
+    @Transactional
+    override fun invoke(meetingTeamId: UUID): MeetingTeamCreateInvitationUseCase.Result {
+        val currentUserId = getCurrentUserAuthentication().userId
+
+        val meetingTeam = meetingTeamDomainService.getById(meetingTeamId)
+            .also {
+                validate(
+                    meetingTeamId = it.id,
+                    currentUserId = currentUserId,
+                )
+            }
+
+        val invitationLink = meetingTeamInvitationService.create(meetingTeam.id)
+
+        return MeetingTeamCreateInvitationUseCase.Result(
+            invitationLink = invitationLink,
+        )
+    }
+
+    private fun validate(
+        meetingTeamId: UUID,
+        currentUserId: UUID,
+    ) {
+        validateCurrentUserIsLeader(
+            meetingTeamId = meetingTeamId,
+            currentUserId = currentUserId,
+        )
+        validateTeamVacancy(meetingTeamId)
+    }
+
+    private fun validateCurrentUserIsLeader(
+        meetingTeamId: UUID,
+        currentUserId: UUID,
+    ) {
+        val meetingTeamLeader =
+            meetingTeamDomainService.getLeaderMemberByMeetingTeamId(meetingTeamId)
+
+        require(meetingTeamLeader.userId == currentUserId) {
+            "팀장만 새로운 팀원을 초대할 수 있어요!"
+        }
+    }
+
+    private fun validateTeamVacancy(meetingTeamId: UUID) {
+        val meetingTeam = meetingTeamDomainService.getById(meetingTeamId)
+
+        require(
+            meetingTeam.status == MeetingTeamStatus.WAITING && validateTeamVacancyIsNotFull(
+                meetingTeam
+            )
+        ) {
+            "팀의 정원이 이미 가득 차 있어서 새로운 팀원을 초대할 수 없어요!"
+        }
+    }
+
+    private fun validateTeamVacancyIsNotFull(meetingTeam: MeetingTeam): Boolean {
+        return meetingTeamDomainService.findAllMeetingMembersByMeetingTeamId(meetingTeam.id).size < meetingTeam.memberCount
+    }
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/util/MeetingTeamInvitationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/util/MeetingTeamInvitationService.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.application.meetingTeam.util
+
+import java.util.*
+
+interface MeetingTeamInvitationService {
+
+    fun create(teamId: UUID): String
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/util/impl/MeetingTeamInvitationServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/util/impl/MeetingTeamInvitationServiceImpl.kt
@@ -1,0 +1,37 @@
+package com.studentcenter.weave.application.meetingTeam.util.impl
+
+import com.studentcenter.weave.application.common.properties.MeetingTeamInvitationProperties
+import com.studentcenter.weave.application.meetingTeam.port.outbound.MeetingTeamInvitationRepository
+import com.studentcenter.weave.application.meetingTeam.util.MeetingTeamInvitationService
+import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInvitation
+import com.studentcenter.weave.support.common.uuid.UuidCreator
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class MeetingTeamInvitationServiceImpl(
+    private val meetingTeamInvitationProperties: MeetingTeamInvitationProperties,
+    private val meetingTeamInvitationRepository: MeetingTeamInvitationRepository,
+) : MeetingTeamInvitationService {
+
+    override fun create(teamId: UUID): String {
+        val invitationLink = generateInvitationLink()
+
+        meetingTeamInvitationRepository.save(
+            MeetingTeamInvitation.of(
+                teamId = teamId,
+                invitationLink = invitationLink,
+                expirationDuration = meetingTeamInvitationProperties.expireSeconds,
+            )
+        )
+
+        return invitationLink
+    }
+
+    private fun generateInvitationLink(): String {
+        val invitationCode = UuidCreator.create()
+
+        return meetingTeamInvitationProperties.urlPrefix + invitationCode
+    }
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/vo/MeetingTeamInvitation.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/vo/MeetingTeamInvitation.kt
@@ -1,0 +1,28 @@
+package com.studentcenter.weave.application.meetingTeam.vo
+
+import java.util.*
+import kotlin.time.Duration
+
+data class MeetingTeamInvitation(
+    val teamId: UUID,
+    val invitationLink: String,
+    val expirationDuration: Duration,
+) {
+
+    companion object {
+
+        fun of(
+            teamId: UUID,
+            invitationLink: String,
+            expirationDuration: Duration,
+        ): MeetingTeamInvitation {
+            return MeetingTeamInvitation(
+                teamId = teamId,
+                invitationLink = invitationLink,
+                expirationDuration = expirationDuration
+            )
+        }
+
+    }
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/user/service/application/UserQueryApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/user/service/application/UserQueryApplicationService.kt
@@ -9,7 +9,7 @@ import java.util.*
 @Service
 class UserQueryApplicationService(
     private val userDomainService: UserDomainService,
-): UserQueryUseCase {
+) : UserQueryUseCase {
 
     override fun getById(id: UUID): User {
         return userDomainService.getById(id)

--- a/application/src/main/resources/application-application.yaml
+++ b/application/src/main/resources/application-application.yaml
@@ -16,3 +16,9 @@ auth:
         jwks-uri: ${APPLE_JWKS_URI:https://appleid.apple.com/auth/keys}
       kakao:
         jwks-uri: ${KAKAO_JWKS_URI:https://kauth.kakao.com/.well-known/jwks.json}
+
+meeting:
+  team:
+    invitation:
+      url-prefix: ${INVITATION_URL_PREFIX:https://api.dev.team-weave.me?code=}
+      expire-seconds: ${INVITATION_EXPIRE_SECONDS:3600}

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateInvitationApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateInvitationApplicationServiceTest.kt
@@ -1,0 +1,173 @@
+package com.studentcenter.weave.application.meetingTeam.service.application
+
+import com.studentcenter.weave.application.common.properties.MeetingTeamInvitationPropertiesFixtureFactory
+import com.studentcenter.weave.application.common.security.context.UserSecurityContext
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingMemberRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamInvitationRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamMemberSummaryRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.service.domain.impl.MeetingTeamDomainServiceImpl
+import com.studentcenter.weave.application.meetingTeam.util.impl.MeetingTeamInvitationServiceImpl
+import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCaseStub
+import com.studentcenter.weave.application.user.port.outbound.UserRepositorySpy
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingMember
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
+import com.studentcenter.weave.domain.meetingTeam.enums.MeetingMemberRole
+import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import com.studentcenter.weave.support.security.context.SecurityContextHolder
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import java.util.*
+
+@DisplayName("MeetingTeamCreateInvitationApplicationServiceTest")
+class MeetingTeamCreateInvitationApplicationServiceTest : DescribeSpec({
+
+    val meetingTeamRepository = MeetingTeamRepositorySpy()
+    val meetingMemberRepository = MeetingMemberRepositorySpy()
+    val meetingTeamMemberSummaryRepository = MeetingTeamMemberSummaryRepositorySpy()
+    val userQueryUseCase = UserQueryUseCaseStub()
+
+    val meetingTeamDomainService = MeetingTeamDomainServiceImpl(
+        meetingTeamRepository = meetingTeamRepository,
+        meetingMemberRepository = meetingMemberRepository,
+        meetingTeamMemberSummaryRepository = meetingTeamMemberSummaryRepository,
+        userQueryUseCase = userQueryUseCase
+    )
+
+    val meetingTeamInvitationRepositorySpy = MeetingTeamInvitationRepositorySpy()
+    val meetingTeamInvitationService = MeetingTeamInvitationServiceImpl(
+        meetingTeamInvitationProperties = MeetingTeamInvitationPropertiesFixtureFactory.create(),
+        meetingTeamInvitationRepository = meetingTeamInvitationRepositorySpy,
+    )
+
+    val userRepository = UserRepositorySpy()
+
+    val sut = MeetingTeamCreateInvitationApplicationService(
+        meetingTeamInvitationService = meetingTeamInvitationService,
+        meetingTeamDomainService = meetingTeamDomainService,
+    )
+
+    afterTest {
+        SecurityContextHolder.clearContext()
+        meetingTeamRepository.clear()
+        meetingTeamInvitationRepositorySpy.clear()
+        userRepository.clear()
+    }
+
+    fun createMember(meetingTeamId: UUID, userId: UUID, role: MeetingMemberRole) {
+        val member = MeetingMember.create(
+            meetingTeamId = meetingTeamId,
+            userId = userId,
+            role = role,
+        )
+
+        meetingMemberRepository.save(member)
+    }
+
+    describe("미팅 팀 새로운 팀원 초대") {
+        context("현재 유저가 팀장인 경우") {
+            it("초대 링크를 정상적으로 발급한다.") {
+                // arrange
+                val meetingTeam = MeetingTeamFixtureFactory.create()
+                val currentUser = UserFixtureFactory.create()
+
+                createMember(
+                    meetingTeamId = meetingTeam.id,
+                    userId = currentUser.id,
+                    role = MeetingMemberRole.LEADER,
+                )
+
+                meetingTeamRepository.save(meetingTeam)
+
+                val userAuthentication = UserAuthenticationFixtureFactory.create(currentUser)
+
+                SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
+
+                // act & assert
+                val invitationCode = sut.invoke(
+                    meetingTeamId = meetingTeam.id,
+                )
+
+                // assert
+                invitationCode.shouldNotBeNull()
+            }
+        }
+
+        context("현재 유저가 팀장이 아닌 경우") {
+            it("에러가 발생한다.") {
+                // arrange
+                val meetingTeam = MeetingTeamFixtureFactory.create()
+                val currentUser = UserFixtureFactory.create()
+                val leaderUser = UserFixtureFactory.create()
+
+                createMember(
+                    meetingTeamId = meetingTeam.id,
+                    userId = leaderUser.id,
+                    role = MeetingMemberRole.LEADER,
+                )
+
+                meetingTeamRepository.save(meetingTeam)
+
+                val userAuthentication = UserAuthenticationFixtureFactory.create(currentUser)
+
+                SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
+
+                // act & assert
+                shouldThrow<IllegalArgumentException> {
+                    sut.invoke(
+                        meetingTeamId = meetingTeam.id,
+                    )
+                }
+            }
+        }
+
+        context("팀의 정원이 가득 찬 경우에 새로운 팀원을 초대하려는 경우") {
+            it("에러가 발생한다.") {
+                // arrange
+                val meetingTeam = MeetingTeamFixtureFactory.create()
+                val leaderUser = UserFixtureFactory.create()
+                val user1 = UserFixtureFactory.create()
+                val user2 = UserFixtureFactory.create()
+                val user3 = UserFixtureFactory.create()
+
+                createMember(
+                    meetingTeamId = meetingTeam.id,
+                    userId = leaderUser.id,
+                    role = MeetingMemberRole.LEADER,
+                )
+                createMember(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user1.id,
+                    role = MeetingMemberRole.MEMBER,
+                )
+                createMember(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user2.id,
+                    role = MeetingMemberRole.MEMBER,
+                )
+                createMember(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user3.id,
+                    role = MeetingMemberRole.MEMBER,
+                )
+
+                meetingTeamRepository.save(meetingTeam)
+
+                val userAuthentication = UserAuthenticationFixtureFactory.create(leaderUser)
+
+                SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
+
+                // act & assert
+                shouldThrow<IllegalArgumentException> {
+                    sut.invoke(
+                        meetingTeamId = meetingTeam.id,
+                    )
+                }
+            }
+        }
+
+    }
+})

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/util/impl/MeetingTeamInvitationServiceImplTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/util/impl/MeetingTeamInvitationServiceImplTest.kt
@@ -1,0 +1,36 @@
+package com.studentcenter.weave.application.meetingTeam.service.util.impl
+
+import com.studentcenter.weave.application.common.properties.MeetingTeamInvitationPropertiesFixtureFactory
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamInvitationRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.util.impl.MeetingTeamInvitationServiceImpl
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+@DisplayName("MeetingTeamInvitationServiceImpl")
+class MeetingTeamInvitationServiceImplTest : DescribeSpec({
+
+    val meetingTeamInvitationProperties = MeetingTeamInvitationPropertiesFixtureFactory.create()
+    val meetingTeamInvitationRepository = MeetingTeamInvitationRepositorySpy()
+
+    val sut = MeetingTeamInvitationServiceImpl(
+        meetingTeamInvitationProperties = meetingTeamInvitationProperties,
+        meetingTeamInvitationRepository = meetingTeamInvitationRepository,
+    )
+
+    describe("create") {
+        it("랜덤 UUID와 함께 초대 링크를 생성한다.") {
+            // arrange
+            val meetingTeam = MeetingTeamFixtureFactory.create()
+
+            // act
+            val actual: String = sut.create(meetingTeam.id)
+
+            // assert
+            // TODO 초대 링크 조회 API 작업 후 변경하기
+            actual.shouldNotBeNull()
+        }
+    }
+
+})

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/common/properties/MeetingTeamInvitationPropertiesFixtureFactory.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/common/properties/MeetingTeamInvitationPropertiesFixtureFactory.kt
@@ -1,0 +1,21 @@
+package com.studentcenter.weave.application.common.properties
+
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+class MeetingTeamInvitationPropertiesFixtureFactory {
+
+    companion object {
+        private const val INVITATION_URL_PREFIX = "https://api.dev.team-weave.me?code="
+        private val DEFAULT_EXPIRE_DURATION = 3600L.toDuration(DurationUnit.SECONDS)
+
+        fun create(): MeetingTeamInvitationProperties {
+            return MeetingTeamInvitationProperties(
+                expireSeconds = DEFAULT_EXPIRE_DURATION,
+                urlPrefix = INVITATION_URL_PREFIX,
+            )
+        }
+
+    }
+
+}

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/outbound/MeetingTeamInvitationRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/outbound/MeetingTeamInvitationRepositorySpy.kt
@@ -1,0 +1,20 @@
+package com.studentcenter.weave.application.meetingTeam.outbound
+
+import com.studentcenter.weave.application.meetingTeam.port.outbound.MeetingTeamInvitationRepository
+import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInvitation
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+class MeetingTeamInvitationRepositorySpy : MeetingTeamInvitationRepository {
+
+    private val bucket = ConcurrentHashMap<String, UUID>()
+
+    override fun save(meetingTeamInvitation: MeetingTeamInvitation) {
+        bucket[meetingTeamInvitation.invitationLink] = meetingTeamInvitation.teamId
+    }
+
+    fun clear() {
+        bucket.clear()
+    }
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/api/MeetingTeamApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/api/MeetingTeamApi.kt
@@ -1,6 +1,7 @@
 package com.studentcenter.weave.bootstrap.meetingTeam.api
 
 import com.studentcenter.weave.bootstrap.common.security.annotation.Secured
+import com.studentcenter.weave.bootstrap.meetingTeam.dto.MeetingTeamCreateInvitationResponse
 import com.studentcenter.weave.bootstrap.meetingTeam.dto.MeetingTeamCreateRequest
 import com.studentcenter.weave.bootstrap.meetingTeam.dto.MeetingTeamEditRequest
 import com.studentcenter.weave.bootstrap.meetingTeam.dto.MeetingTeamGetDetailResponse
@@ -93,5 +94,14 @@ interface MeetingTeamApi {
         @PathVariable
         id: UUID
     )
+
+    @Secured
+    @Operation(summary = "Create meeting team invitation code")
+    @PostMapping("/{meetingTeamId}/invitation")
+    @ResponseStatus(HttpStatus.OK)
+    fun createMeetingTeamInvitation(
+        @PathVariable
+        meetingTeamId: UUID
+    ): MeetingTeamCreateInvitationResponse
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/controller/MeetingTeamRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/controller/MeetingTeamRestController.kt
@@ -1,5 +1,6 @@
 package com.studentcenter.weave.bootstrap.meetingTeam.controller
 
+import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamCreateInvitationUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamCreateUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamDeleteUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamEditUseCase
@@ -8,6 +9,7 @@ import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamG
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamGetMyUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamLeaveUseCase
 import com.studentcenter.weave.bootstrap.meetingTeam.api.MeetingTeamApi
+import com.studentcenter.weave.bootstrap.meetingTeam.dto.MeetingTeamCreateInvitationResponse
 import com.studentcenter.weave.bootstrap.meetingTeam.dto.MeetingTeamCreateRequest
 import com.studentcenter.weave.bootstrap.meetingTeam.dto.MeetingTeamEditRequest
 import com.studentcenter.weave.bootstrap.meetingTeam.dto.MeetingTeamGetDetailResponse
@@ -29,6 +31,7 @@ class MeetingTeamRestController(
     private val meetingTeamGetDetailUseCase: MeetingTeamGetDetailUseCase,
     private val meetingTeamLeaveUseCase: MeetingTeamLeaveUseCase,
     private val meetingTeamGetListUseCase: MeetingTeamGetListUseCase,
+    private val meetingTeamCreateInvitationUseCase: MeetingTeamCreateInvitationUseCase,
 ) : MeetingTeamApi {
 
     override fun createMeetingTeam(request: MeetingTeamCreateRequest) {
@@ -102,6 +105,14 @@ class MeetingTeamRestController(
 
     override fun leaveMeetingTeam(id: UUID) {
         meetingTeamLeaveUseCase.invoke(MeetingTeamLeaveUseCase.Command(id))
+    }
+
+    override fun createMeetingTeamInvitation(meetingTeamId: UUID): MeetingTeamCreateInvitationResponse {
+        val result = meetingTeamCreateInvitationUseCase.invoke(meetingTeamId)
+
+        return MeetingTeamCreateInvitationResponse(
+            invitationLink = result.invitationLink,
+        )
     }
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/dto/MeetingTeamCreateInvitationResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/dto/MeetingTeamCreateInvitationResponse.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.bootstrap.meetingTeam.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "미팅 팀 초대 코드 생성 응답")
+data class MeetingTeamCreateInvitationResponse(
+    @Schema(description = "초대 코드")
+    val invitationLink: String,
+)

--- a/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/meetingTeam/adapter/MeetingTeamInvitationRedisAdapter.kt
+++ b/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/meetingTeam/adapter/MeetingTeamInvitationRedisAdapter.kt
@@ -1,0 +1,25 @@
+package com.studentcenter.weave.infrastructure.redis.meetingTeam.adapter
+
+import com.studentcenter.weave.application.meetingTeam.port.outbound.MeetingTeamInvitationRepository
+import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInvitation
+import com.studentcenter.weave.infrastructure.redis.meetingTeam.entity.MeetingTeamInvitationRedisHash
+import com.studentcenter.weave.infrastructure.redis.meetingTeam.repository.MeetingTeamInvitationRedisRepository
+import org.springframework.stereotype.Component
+
+@Component
+class MeetingTeamInvitationRedisAdapter(
+    private val meetingTeamInvitationRedisRepository: MeetingTeamInvitationRedisRepository,
+) : MeetingTeamInvitationRepository {
+
+    override fun save(
+        meetingTeamInvitation: MeetingTeamInvitation,
+    ) {
+        val meetingTeamInvitationRedisHash = MeetingTeamInvitationRedisHash(
+            invitationLink = meetingTeamInvitation.invitationLink,
+            teamId = meetingTeamInvitation.teamId,
+            expirationDuration = meetingTeamInvitation.expirationDuration,
+        )
+        meetingTeamInvitationRedisRepository.save(meetingTeamInvitationRedisHash)
+    }
+
+}

--- a/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/meetingTeam/entity/MeetingTeamInvitationRedisHash.kt
+++ b/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/meetingTeam/entity/MeetingTeamInvitationRedisHash.kt
@@ -1,0 +1,27 @@
+package com.studentcenter.weave.infrastructure.redis.meetingTeam.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+import java.util.*
+import kotlin.time.Duration
+
+@RedisHash("meeting_team_invitation")
+class MeetingTeamInvitationRedisHash(
+    teamId: UUID,
+    invitationLink: String,
+    expirationDuration: Duration,
+) {
+
+    @Id
+    var invitationLink: String = invitationLink
+        private set
+
+    var teamId: UUID = teamId
+        private set
+
+    @TimeToLive
+    var expirationDuration: Duration = expirationDuration
+        private set
+
+}

--- a/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/meetingTeam/repository/MeetingTeamInvitationRedisRepository.kt
+++ b/infrastructure/redis/src/main/kotlin/com/studentcenter/weave/infrastructure/redis/meetingTeam/repository/MeetingTeamInvitationRedisRepository.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.infrastructure.redis.meetingTeam.repository
+
+import com.studentcenter.weave.infrastructure.redis.meetingTeam.entity.MeetingTeamInvitationRedisHash
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MeetingTeamInvitationRedisRepository :
+    CrudRepository<MeetingTeamInvitationRedisHash, String>


### PR DESCRIPTION
## Background

- 미팅 팀 초대 기능

![image](https://github.com/Student-Center/weave-server/assets/59856002/997b09a0-12a1-4dcd-9082-d33bc5b95afc)


## **Methodology & Design(Proposal)**

### Goals

- 미팅 팀 초대 기능을 구현합니다.
    - 초대 링크를 생성하여 팀원을 초대할 수 있어야 합니다.
        - 초대 링크 생성은 **팀장만 가능합니다.**


### API

- **초대 링크 생성**
    - POST */api/meeting-teams/{meetingTeamId}/invitation*
        - request
            - method & path: `POST */api/meeting-teams/{meetingTeamId}/invitation*`
            - body
                
                ```json
                --
                ```
                
        
        - response
            - 정상 처리된 경우
                - status code: `200 OK`
                - body
                    
                    ```jsx
                    {
                        "invitationLink" : "https://api.dev.team-weave.me?code=018dc0f9-0450-75fb-a0cf-e795d9c3e794" // String
                    }
                    ```

                    - invitationLink : 초대 링크


### 구현 세부사항
* 초대 링크는 랜덤 UUID값을 사용합니다.
* 생성한 링크를 RDB 대신 Redis에 따로 저장하도록 구현하였습니다.
* 초대 링크의 TTL은 1시간입니다.