### PR TITLE
[WEAV-252] 초대 링크 생성 API URL 수정

### DIFF
--- a/application/src/main/resources/application-application.yaml
+++ b/application/src/main/resources/application-application.yaml
@@ -20,5 +20,9 @@ auth:
 meeting:
   team:
     invitation:
+      # 개발 환경 url
       url-prefix: ${INVITATION_URL_PREFIX:https://api.dev.team-weave.me/invitations?code=}
       expire-seconds: ${INVITATION_EXPIRE_SECONDS:3600}
+
+      # TODO : 운영 환경 url로 변경 필요
+      # url-prefix: ${INVITATION_URL_PREFIX:https://api.team-weave.me/invitations?code=}

--- a/application/src/main/resources/application-application.yaml
+++ b/application/src/main/resources/application-application.yaml
@@ -24,31 +24,6 @@ meeting:
       expire-seconds: ${INVITATION_EXPIRE_SECONDS:3600}
 
 # TODO : 운영 환경 url-prefix 변경 필요
-#---
-#spring:
-#  config:
-#    activate:
-#      on-profile: prod
-#
-#auth:
-#  jwt:
-#    issuer: ${JWT_ISSUER:weave}
-#    access:
-#      expire-seconds: ${JWT_ACCESS_EXPIRE_SECONDS:3600}
-#      secret: ${JWT_ACCESS_SECRET:secret}
-#    refresh:
-#      expire-seconds: ${JWT_REFRESH_EXPIRE_SECONDS:604800}
-#      secret: ${JWT_REFRESH_SECRET:secret}
-#    register:
-#      expire-seconds: ${JWT_REGISTER_EXPIRE_SECONDS:300}
-#      secret: ${JWT_REGISTER_SECRET:secret}
-#  open-id:
-#    providers:
-#      apple:
-#        jwks-uri: ${APPLE_JWKS_URI:https://appleid.apple.com/auth/keys}
-#      kakao:
-#        jwks-uri: ${KAKAO_JWKS_URI:https://kauth.kakao.com/.well-known/jwks.json}
-#
 #meeting:
 #  team:
 #    invitation:

--- a/application/src/main/resources/application-application.yaml
+++ b/application/src/main/resources/application-application.yaml
@@ -24,6 +24,11 @@ meeting:
       expire-seconds: ${INVITATION_EXPIRE_SECONDS:3600}
 
 # TODO : 운영 환경 url-prefix 변경 필요
+#spring:
+#  config:
+#    activate:
+#      on-profile: prod
+
 #meeting:
 #  team:
 #    invitation:

--- a/application/src/main/resources/application-application.yaml
+++ b/application/src/main/resources/application-application.yaml
@@ -23,14 +23,14 @@ meeting:
       url-prefix: ${INVITATION_URL_PREFIX:https://api.dev.team-weave.me/invitations?code=}
       expire-seconds: ${INVITATION_EXPIRE_SECONDS:3600}
 
-# TODO : 운영 환경 url-prefix 변경 필요
-#spring:
-#  config:
-#    activate:
-#      on-profile: prod
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
 
-#meeting:
-#  team:
-#    invitation:
-#      url-prefix: ${INVITATION_URL_PREFIX:https://api.team-weave.me/invitations?code=}
-#      expire-seconds: ${INVITATION_EXPIRE_SECONDS:3600}
+meeting:
+  team:
+    invitation:
+      url-prefix: ${INVITATION_URL_PREFIX:https://api.team-weave.me/invitations?code=}
+      expire-seconds: ${INVITATION_EXPIRE_SECONDS:3600}

--- a/application/src/main/resources/application-application.yaml
+++ b/application/src/main/resources/application-application.yaml
@@ -20,9 +20,37 @@ auth:
 meeting:
   team:
     invitation:
-      # 개발 환경 url
       url-prefix: ${INVITATION_URL_PREFIX:https://api.dev.team-weave.me/invitations?code=}
       expire-seconds: ${INVITATION_EXPIRE_SECONDS:3600}
 
-      # TODO : 운영 환경 url로 변경 필요
-      # url-prefix: ${INVITATION_URL_PREFIX:https://api.team-weave.me/invitations?code=}
+# TODO : 운영 환경 url-prefix 변경 필요
+#---
+#spring:
+#  config:
+#    activate:
+#      on-profile: prod
+#
+#auth:
+#  jwt:
+#    issuer: ${JWT_ISSUER:weave}
+#    access:
+#      expire-seconds: ${JWT_ACCESS_EXPIRE_SECONDS:3600}
+#      secret: ${JWT_ACCESS_SECRET:secret}
+#    refresh:
+#      expire-seconds: ${JWT_REFRESH_EXPIRE_SECONDS:604800}
+#      secret: ${JWT_REFRESH_SECRET:secret}
+#    register:
+#      expire-seconds: ${JWT_REGISTER_EXPIRE_SECONDS:300}
+#      secret: ${JWT_REGISTER_SECRET:secret}
+#  open-id:
+#    providers:
+#      apple:
+#        jwks-uri: ${APPLE_JWKS_URI:https://appleid.apple.com/auth/keys}
+#      kakao:
+#        jwks-uri: ${KAKAO_JWKS_URI:https://kauth.kakao.com/.well-known/jwks.json}
+#
+#meeting:
+#  team:
+#    invitation:
+#      url-prefix: ${INVITATION_URL_PREFIX:https://api.team-weave.me/invitations?code=}
+#      expire-seconds: ${INVITATION_EXPIRE_SECONDS:3600}

--- a/application/src/main/resources/application-application.yaml
+++ b/application/src/main/resources/application-application.yaml
@@ -20,5 +20,5 @@ auth:
 meeting:
   team:
     invitation:
-      url-prefix: ${INVITATION_URL_PREFIX:https://api.dev.team-weave.me?code=}
+      url-prefix: ${INVITATION_URL_PREFIX:https://api.dev.team-weave.me/invitations?code=}
       expire-seconds: ${INVITATION_EXPIRE_SECONDS:3600}


### PR DESCRIPTION
### 변경사항
* 생성되는 초대 링크 URL을 다음과 같이 수정했습니다.

[변경 전]
`https://api.dev.team-weave.me?code=`

[변경 후]
`https://api.dev.team-weave.me/invitations?code=`

### 전달사항
* 2/23 9시쯤 해당 초대 링크 동작 + 앱링크 관련해서 AOS 장훈님과 함께 테스팅 진행하기로 했습니다!