### PR TITLE
[WEAV-246] 팀 상세조회 응답 테스트 수정

### DIFF
--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamGetDetailApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamGetDetailApplicationServiceTest.kt
@@ -68,7 +68,10 @@ class MeetingTeamGetDetailApplicationServiceTest : DescribeSpec({
                 UserFixtureFactory
                     .create()
                     .let { UserAuthenticationFixtureFactory.create(it) }
-                    .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
+                    .also {
+                        SecurityContextHolder.setContext(UserSecurityContext(it))
+                        meetingTeamRepositorySpy.mapUserIdAndTeamId(it.userId, targetMeetingTeam.id)
+                    }
 
                 // act
                 val result = sut.invoke(MeetingTeamGetDetailUseCase.Command(targetMeetingTeam.id))
@@ -99,7 +102,11 @@ class MeetingTeamGetDetailApplicationServiceTest : DescribeSpec({
                 UserFixtureFactory
                     .create()
                     .let { UserAuthenticationFixtureFactory.create(it) }
-                    .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
+                    .also {
+                        SecurityContextHolder.setContext(UserSecurityContext(it))
+                        meetingTeamRepositorySpy.mapUserIdAndTeamId(it.userId, myMeetingTeam.id)
+                    }
+
 
                 // act
                 val result = sut.invoke(MeetingTeamGetDetailUseCase.Command(targetMeetingTeam.id))
@@ -113,7 +120,7 @@ class MeetingTeamGetDetailApplicationServiceTest : DescribeSpec({
         context("내 미팅팀이 아니고, 내팀(WAITING), 상대팀(PUBLISH) 상태인 경우") {
             it("미팅팀 정보를 조회한다 - 케미 점수(O)") {
                 // arrange
-                MeetingTeamFixtureFactory
+                val myMeetingTeam = MeetingTeamFixtureFactory
                     .create(status = MeetingTeamStatus.WAITING)
                     .also { meetingTeamRepositorySpy.save(it) }
                 val targetMeetingTeam = MeetingTeamFixtureFactory
@@ -127,7 +134,10 @@ class MeetingTeamGetDetailApplicationServiceTest : DescribeSpec({
                 UserFixtureFactory
                     .create()
                     .let { UserAuthenticationFixtureFactory.create(it) }
-                    .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
+                    .also {
+                        SecurityContextHolder.setContext(UserSecurityContext(it))
+                        meetingTeamRepositorySpy.mapUserIdAndTeamId(it.userId, myMeetingTeam.id)
+                    }
 
                 // act
                 val result = sut.invoke(MeetingTeamGetDetailUseCase.Command(targetMeetingTeam.id))
@@ -155,7 +165,10 @@ class MeetingTeamGetDetailApplicationServiceTest : DescribeSpec({
                 UserFixtureFactory
                     .create()
                     .let { UserAuthenticationFixtureFactory.create(it) }
-                    .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
+                    .also {
+                        SecurityContextHolder.setContext(UserSecurityContext(it))
+                        meetingTeamRepositorySpy.mapUserIdAndTeamId(it.userId, myMeetingTeam.id)
+                    }
 
                 // act
                 val result = sut.invoke(MeetingTeamGetDetailUseCase.Command(targetMeetingTeam.id))

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamGetDetailApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamGetDetailApplicationServiceTest.kt
@@ -70,7 +70,7 @@ class MeetingTeamGetDetailApplicationServiceTest : DescribeSpec({
                     .let { UserAuthenticationFixtureFactory.create(it) }
                     .also {
                         SecurityContextHolder.setContext(UserSecurityContext(it))
-                        meetingTeamRepositorySpy.mapUserIdAndTeamId(it.userId, targetMeetingTeam.id)
+                        meetingTeamRepositorySpy.putUserToTeamMember(it.userId, targetMeetingTeam.id)
                     }
 
                 // act
@@ -104,7 +104,7 @@ class MeetingTeamGetDetailApplicationServiceTest : DescribeSpec({
                     .let { UserAuthenticationFixtureFactory.create(it) }
                     .also {
                         SecurityContextHolder.setContext(UserSecurityContext(it))
-                        meetingTeamRepositorySpy.mapUserIdAndTeamId(it.userId, myMeetingTeam.id)
+                        meetingTeamRepositorySpy.putUserToTeamMember(it.userId, myMeetingTeam.id)
                     }
 
 
@@ -136,7 +136,7 @@ class MeetingTeamGetDetailApplicationServiceTest : DescribeSpec({
                     .let { UserAuthenticationFixtureFactory.create(it) }
                     .also {
                         SecurityContextHolder.setContext(UserSecurityContext(it))
-                        meetingTeamRepositorySpy.mapUserIdAndTeamId(it.userId, myMeetingTeam.id)
+                        meetingTeamRepositorySpy.putUserToTeamMember(it.userId, myMeetingTeam.id)
                     }
 
                 // act
@@ -167,7 +167,7 @@ class MeetingTeamGetDetailApplicationServiceTest : DescribeSpec({
                     .let { UserAuthenticationFixtureFactory.create(it) }
                     .also {
                         SecurityContextHolder.setContext(UserSecurityContext(it))
-                        meetingTeamRepositorySpy.mapUserIdAndTeamId(it.userId, myMeetingTeam.id)
+                        meetingTeamRepositorySpy.putUserToTeamMember(it.userId, myMeetingTeam.id)
                     }
 
                 // act

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/outbound/MeetingTeamRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/outbound/MeetingTeamRepositorySpy.kt
@@ -57,7 +57,7 @@ class MeetingTeamRepositorySpy : MeetingTeamRepository {
         return bucket.values.toList()
     }
 
-    fun mapUserIdAndTeamId(userId: UUID, teamId: UUID) {
+    fun putUserToTeamMember(userId: UUID, teamId: UUID) {
         memberUserIdToTeamIdMap[userId] = teamId
     }
 

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/outbound/MeetingTeamRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/outbound/MeetingTeamRepositorySpy.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.ConcurrentHashMap
 class MeetingTeamRepositorySpy : MeetingTeamRepository {
 
     private val bucket = ConcurrentHashMap<UUID, MeetingTeam>()
+    private val memberUserIdToTeamIdMap = ConcurrentHashMap<UUID, UUID>()
 
     override fun save(meetingTeam: MeetingTeam) {
         bucket[meetingTeam.id] = meetingTeam
@@ -27,11 +28,13 @@ class MeetingTeamRepositorySpy : MeetingTeamRepository {
     }
 
     override fun getByMemberUserId(userId: UUID): MeetingTeam {
-        return bucket.values.first()
+        val meetingTeamId: UUID = memberUserIdToTeamIdMap[userId] ?: throw NoSuchElementException()
+        return bucket[meetingTeamId] ?: throw NoSuchElementException()
     }
 
     override fun findByMemberUserId(userId: UUID): MeetingTeam? {
-        return bucket.values.first()
+        val meetingTeamId: UUID = memberUserIdToTeamIdMap[userId] ?: return null
+        return bucket[meetingTeamId]
     }
 
     override fun scrollByMemberUserId(
@@ -52,6 +55,10 @@ class MeetingTeamRepositorySpy : MeetingTeamRepository {
         limit: Int
     ): List<MeetingTeam> {
         return bucket.values.toList()
+    }
+
+    fun mapUserIdAndTeamId(userId: UUID, teamId: UUID) {
+        memberUserIdToTeamIdMap[userId] = teamId
     }
 
     fun findById(id: UUID): MeetingTeam? {


### PR DESCRIPTION
- MeetingRepository 팀과 멤버 유저를 조인해서 쿼리하는 메서드(getByMemberUserId)가 있는데, 해당 메서드의 Spy 응답을 단순하게 first로 만들어 두어서 테스트가 실패했어요.
- 구체적으로 상황 지정할 수 있도록 spy 메서드 추가하고 테스트 수정했어요