### PR TITLE
[WEAV-153] 미팅팀 목록 조회 다수 Location 쿼리 버그 수정

### DIFF
--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/adapter/MeetingTeamJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/adapter/MeetingTeamJpaAdapter.kt
@@ -93,7 +93,7 @@ class MeetingTeamJpaAdapter(
                 memberCount = filter.memberCount,
                 youngestMemberBirthYear = filter.youngestMemberBirthYear,
                 oldestMemberBirthYear = filter.oldestMemberBirthYear,
-                preferredLocations = filter.preferredLocations?.map { it.name },
+                preferredLocations = filter.preferredLocations?.map { it.name }?.toTypedArray(),
                 gender = filter.gender?.name,
                 status = filter.status.name,
                 next = next,

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/repository/MeetingTeamJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meetingTeam/repository/MeetingTeamJpaRepository.kt
@@ -4,6 +4,7 @@ import com.studentcenter.weave.domain.meetingTeam.enums.MeetingTeamStatus
 import com.studentcenter.weave.infrastructure.persistence.meetingTeam.entity.MeetingTeamJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.*
 
@@ -77,7 +78,8 @@ interface MeetingTeamJpaRepository : JpaRepository<MeetingTeamJpaEntity, UUID> {
         memberCount: Int?,
         youngestMemberBirthYear: Int,
         oldestMemberBirthYear: Int,
-        preferredLocations: List<String>?,
+        @Param("preferredLocations")
+        preferredLocations: Array<String>?,
         gender: String?,
         status: String?,
         next: UUID?,


### PR DESCRIPTION
- 미팅팀 목록조회시 Location이 여러개일경우 쿼리가 제대로 되지 않는 현상을 해결했어요
  - JPQL에서는 List를 사용하지 말고 Array를 사용해야함