### PR TITLE
[WEAV-263] 미팅 팀 입장 API

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/inbound/MeetingTeamEnterUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/port/inbound/MeetingTeamEnterUseCase.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.application.meetingTeam.port.inbound
+
+import java.util.*
+
+interface MeetingTeamEnterUseCase {
+
+    fun invoke(invitationCode: UUID)
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateInvitationLinkApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateInvitationLinkApplicationService.kt
@@ -61,4 +61,5 @@ class MeetingTeamCreateInvitationLinkApplicationService(
             "팀의 정원이 이미 가득 차 있어서 새로운 팀원을 초대할 수 없어요!"
         }
     }
+
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamEnterApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamEnterApplicationService.kt
@@ -1,0 +1,48 @@
+package com.studentcenter.weave.application.meetingTeam.service.application
+
+import com.studentcenter.weave.application.common.exception.MeetingTeamExceptionType
+import com.studentcenter.weave.application.common.security.context.getCurrentUserAuthentication
+import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamEnterUseCase
+import com.studentcenter.weave.application.meetingTeam.service.domain.MeetingTeamDomainService
+import com.studentcenter.weave.application.meetingTeam.util.MeetingTeamInvitationService
+import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCase
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeam
+import com.studentcenter.weave.domain.meetingTeam.enums.MeetingMemberRole
+import com.studentcenter.weave.support.common.exception.CustomException
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+class MeetingTeamEnterApplicationService(
+    private val meetingTeamDomainService: MeetingTeamDomainService,
+    private val meetingTeamInvitationService: MeetingTeamInvitationService,
+    private val userQueryUseCase: UserQueryUseCase,
+) : MeetingTeamEnterUseCase {
+
+    override fun invoke(invitationCode: UUID) {
+        val currentUser = getCurrentUserAuthentication().userId
+            .let { userQueryUseCase.getById(it) }
+
+        val meetingTeam =
+            meetingTeamInvitationService.findByInvitationCode(invitationCode = invitationCode)
+                ?.let {
+                    meetingTeamDomainService.getById(it.teamId)
+                } ?: throw CustomException(
+                type = MeetingTeamExceptionType.INVITATION_CODE_NOT_FOUND,
+                message = "초대 링크를 찾을 수 없어요! 새로운 초대 링크를 통해 입장해 주세요!"
+            )
+
+        meetingTeamDomainService.addMember(
+            meetingTeam = meetingTeam,
+            user = currentUser,
+            role = MeetingMemberRole.MEMBER,
+        ).takeIf { isMeetingTeamFull(meetingTeam) }
+            ?.let { meetingTeamDomainService.publishById(meetingTeam.id) }
+
+    }
+
+    private fun isMeetingTeamFull(meetingTeam: MeetingTeam): Boolean {
+        return meetingTeamDomainService.countByMeetingTeamId(meetingTeamId = meetingTeam.id) == meetingTeam.memberCount
+    }
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/MeetingTeamDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/domain/MeetingTeamDomainService.kt
@@ -76,4 +76,6 @@ interface MeetingTeamDomainService {
 
     fun getAllByIds(ids: List<UUID>): List<MeetingTeam>
 
+    fun countByMeetingTeamId(meetingTeamId: UUID): Int
+
 }

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateInvitationApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamCreateInvitationApplicationServiceTest.kt
@@ -114,7 +114,7 @@ class MeetingTeamCreateInvitationApplicationServiceTest : DescribeSpec({
             }
         }
 
-        context("팀의 정원이 가득 찬 경우에 새로운 팀원을 초대하려는 경우") {
+        context("팀의 정원이 가득 찼을 때, 새로운 초대 링크를 발급하려는 경우") {
             it("에러가 발생한다.") {
                 // arrange
                 val meetingTeam = MeetingTeamFixtureFactory.create()

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamEnterApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamEnterApplicationServiceTest.kt
@@ -1,0 +1,178 @@
+package com.studentcenter.weave.application.meetingTeam.service.application
+
+import com.studentcenter.weave.application.common.properties.MeetingTeamInvitationPropertiesFixtureFactory
+import com.studentcenter.weave.application.common.security.context.UserSecurityContext
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingMemberRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamInvitationRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamMemberSummaryRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.service.domain.impl.MeetingTeamDomainServiceImpl
+import com.studentcenter.weave.application.meetingTeam.util.impl.MeetingTeamInvitationServiceImpl
+import com.studentcenter.weave.application.user.port.inbound.UserQueryUseCaseStub
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingMember
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
+import com.studentcenter.weave.domain.meetingTeam.enums.MeetingMemberRole
+import com.studentcenter.weave.domain.meetingTeam.enums.MeetingTeamStatus
+import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import com.studentcenter.weave.support.security.context.SecurityContextHolder
+import com.studentcetner.weave.support.lock.DistributedLockTestInitializer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import org.junit.jupiter.api.DisplayName
+
+@DisplayName("MeetingTeamEnterApplicationServiceTest")
+class MeetingTeamEnterApplicationServiceTest : DescribeSpec({
+
+    val meetingTeamRepository = MeetingTeamRepositorySpy()
+    val meetingMemberRepository = MeetingMemberRepositorySpy()
+    val meetingTeamMemberSummaryRepository = MeetingTeamMemberSummaryRepositorySpy()
+    val userQueryUseCase = UserQueryUseCaseStub()
+
+    val meetingTeamInvitationRepositorySpy = MeetingTeamInvitationRepositorySpy()
+
+    val meetingTeamDomainService = MeetingTeamDomainServiceImpl(
+        meetingTeamRepository = meetingTeamRepository,
+        meetingMemberRepository = meetingMemberRepository,
+        meetingTeamMemberSummaryRepository = meetingTeamMemberSummaryRepository,
+        userQueryUseCase = userQueryUseCase,
+    )
+
+    val meetingTeamInvitationService = MeetingTeamInvitationServiceImpl(
+        meetingTeamInvitationProperties = MeetingTeamInvitationPropertiesFixtureFactory.create(),
+        meetingTeamInvitationRepository = meetingTeamInvitationRepositorySpy,
+    )
+
+    val sut = MeetingTeamEnterApplicationService(
+        meetingTeamDomainService = meetingTeamDomainService,
+        meetingTeamInvitationService = meetingTeamInvitationService,
+        userQueryUseCase = userQueryUseCase,
+    )
+
+    beforeTest {
+        DistributedLockTestInitializer.mockExecutionByStatic()
+    }
+
+    afterTest {
+        meetingTeamRepository.clear()
+        meetingMemberRepository.clear()
+        meetingTeamMemberSummaryRepository.clear()
+        meetingTeamInvitationRepositorySpy.clear()
+        SecurityContextHolder.clearContext()
+        clearAllMocks()
+    }
+
+    describe("미팅 팀 입장 요청") {
+        context("유효하지 않은 코드를 통해 입장을 시도하는 경우") {
+            it("에러가 발생한다.") {
+                // arrange
+                val meetingTeam = MeetingTeamFixtureFactory.create()
+
+                UserFixtureFactory.create()
+                    .let { UserAuthenticationFixtureFactory.create(it) }
+                    .let { SecurityContextHolder.setContext(UserSecurityContext(it)) }
+
+                val meetingTeamInvitation = meetingTeamInvitationService.create(meetingTeam.id)
+
+                // act & assert
+                shouldThrow<NoSuchElementException> {
+                    sut.invoke(meetingTeamInvitation.invitationCode)
+                }
+            }
+        }
+
+        context("유효한 코드를 통해 입장을 시도하는 경우") {
+            it("정상적으로 팀에 초대되어 합류한다.") {
+                // arrange
+                val currentUser = UserFixtureFactory.create()
+                val meetingTeam = MeetingTeamFixtureFactory.create()
+                    .also { meetingTeamRepository.save(it) }
+
+                UserAuthenticationFixtureFactory.create(currentUser)
+                    .let { SecurityContextHolder.setContext(UserSecurityContext(it)) }
+
+                val meetingTeamInvitation = meetingTeamInvitationService.create(meetingTeam.id)
+
+                // act
+                sut.invoke(meetingTeamInvitation.invitationCode)
+
+                // assert
+                val member =
+                    meetingMemberRepository.getByMeetingTeamIdAndUserId(
+                        meetingTeamId = meetingTeam.id,
+                        userId = currentUser.id
+                    )
+
+                member.meetingTeamId shouldBe meetingTeam.id
+            }
+        }
+
+        context("팀에 마지막 멤버가 합류한 경우") {
+            it("팀의 상태를 PUBLISH로 전환한다.") {
+                // arrange
+                val memberCount = 2
+                val leaderUser = UserFixtureFactory.create()
+                val currentUser = UserFixtureFactory.create()
+                val meetingTeam = MeetingTeamFixtureFactory.create(memberCount = memberCount)
+                    .also { meetingTeamRepository.save(it) }
+
+                val meetingTeamMember = MeetingMember.create(
+                    meetingTeamId = meetingTeam.id,
+                    userId = leaderUser.id,
+                    role = MeetingMemberRole.LEADER
+                )
+                meetingMemberRepository.save(meetingTeamMember)
+
+                UserAuthenticationFixtureFactory.create(currentUser)
+                    .let { SecurityContextHolder.setContext(UserSecurityContext(it)) }
+
+                val meetingTeamInvitation = meetingTeamInvitationService.create(meetingTeam.id)
+
+                // act
+                sut.invoke(meetingTeamInvitation.invitationCode)
+
+                // assert
+                meetingTeamDomainService.getById(meetingTeam.id).status shouldBe MeetingTeamStatus.PUBLISHED
+            }
+        }
+
+        context("정원이 가득 찬 팀에 입장하려는 경우") {
+            it("에러가 발생한다.") {
+                // arrange
+                val memberCount = 2
+                val leaderUser = UserFixtureFactory.create()
+                val user1 = UserFixtureFactory.create()
+                val currentUser = UserFixtureFactory.create()
+                val meetingTeam = MeetingTeamFixtureFactory.create(memberCount = memberCount)
+                    .also { meetingTeamRepository.save(it) }
+
+                val meetingTeamMember1 = MeetingMember.create(
+                    meetingTeamId = meetingTeam.id,
+                    userId = leaderUser.id,
+                    role = MeetingMemberRole.LEADER
+                )
+                val meetingTeamMember2 = MeetingMember.create(
+                    meetingTeamId = meetingTeam.id,
+                    userId = user1.id,
+                    role = MeetingMemberRole.MEMBER
+                )
+
+                meetingMemberRepository.save(meetingTeamMember1)
+                meetingMemberRepository.save(meetingTeamMember2)
+
+                UserAuthenticationFixtureFactory.create(currentUser)
+                    .let { SecurityContextHolder.setContext(UserSecurityContext(it)) }
+
+                val meetingTeamInvitation = meetingTeamInvitationService.create(meetingTeam.id)
+
+                // act & assert
+                shouldThrow<IllegalArgumentException> {
+                    sut.invoke(meetingTeamInvitation.invitationCode)
+                }
+            }
+        }
+    }
+
+})

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamGetByInvitationLinkApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamGetByInvitationLinkApplicationServiceTest.kt
@@ -77,7 +77,7 @@ class MeetingTeamGetByInvitationLinkApplicationServiceTest : DescribeSpec({
             }
         }
 
-        context("초대 링크가 존재하는 경우") {
+        context("초대 링크가 유효한 경우") {
             it("미팅팀 상세 조회가 정상적으로 이루어진다.") {
                 // arrange
                 val meetingTeam = MeetingTeamFixtureFactory.create()

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/api/MeetingTeamApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/api/MeetingTeamApi.kt
@@ -114,4 +114,13 @@ interface MeetingTeamApi {
         invitationCode: UUID
     ): MeetingTeamGetByInvitationCodeResponse
 
+    @Secured
+    @Operation(summary = "Enter meeting team")
+    @PostMapping("/invitation/{invitationCode}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun enterMeetingTeam(
+        @PathVariable
+        invitationCode: UUID
+    )
+
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/controller/MeetingTeamRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meetingTeam/controller/MeetingTeamRestController.kt
@@ -4,6 +4,7 @@ import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamC
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamCreateUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamDeleteUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamEditUseCase
+import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamEnterUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamGetByInvitationCodeUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamGetDetailUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamGetListUseCase
@@ -35,6 +36,7 @@ class MeetingTeamRestController(
     private val meetingTeamGetListUseCase: MeetingTeamGetListUseCase,
     private val meetingTeamCreateInvitationLinkUseCase: MeetingTeamCreateInvitationLinkUseCase,
     private val meetingTeamGetByInvitationCodeUseCase: MeetingTeamGetByInvitationCodeUseCase,
+    private val meetingTeamEnterUseCase: MeetingTeamEnterUseCase,
 ) : MeetingTeamApi {
 
     override fun createMeetingTeam(request: MeetingTeamCreateRequest) {
@@ -122,6 +124,10 @@ class MeetingTeamRestController(
     override fun getMeetingTeamByInvitationCode(invitationCode: UUID): MeetingTeamGetByInvitationCodeResponse {
         return meetingTeamGetByInvitationCodeUseCase.invoke(invitationCode)
             .let { MeetingTeamGetByInvitationCodeResponse.of(it) }
+    }
+
+    override fun enterMeetingTeam(invitationCode: UUID) {
+        meetingTeamEnterUseCase.invoke(invitationCode)
     }
 
 }

--- a/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/integration/MeetingTeamDomainServiceIntegrationTest.kt
+++ b/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/integration/MeetingTeamDomainServiceIntegrationTest.kt
@@ -1,0 +1,62 @@
+package com.studentcenter.weave.bootstrap.integration
+
+import com.studentcenter.weave.application.meetingTeam.service.domain.MeetingTeamDomainService
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
+import com.studentcenter.weave.domain.meetingTeam.enums.MeetingMemberRole
+import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+@DisplayName("MeetingTeamDomainService 통합 테스트")
+class MeetingTeamDomainServiceIntegrationTest(
+    private val meetingTeamDomainService: MeetingTeamDomainService,
+) : IntegrationTestDescribeSpec({
+
+    describe("미팅 팀 입장 요청 동시성 테스트") {
+        context("분산락 적용") {
+            it("두 명이 동시에 입장 요청") {
+                // arrange
+                val memberCount = 2
+                var leaderUser = UserFixtureFactory.create()
+                val user1 = UserFixtureFactory.create()
+                val user2 = UserFixtureFactory.create()
+
+                val meetingTeam = MeetingTeamFixtureFactory.create(memberCount = memberCount)
+                meetingTeamDomainService.save(meetingTeam)
+
+                meetingTeamDomainService.addMember(
+                    user = leaderUser,
+                    meetingTeam = meetingTeam,
+                    role = MeetingMemberRole.LEADER
+                )
+
+                // act
+                shouldThrow<IllegalArgumentException> {
+                    runBlocking {
+                        launch(Dispatchers.Default) {
+                            meetingTeamDomainService.addMember(
+                                user = user1,
+                                meetingTeam = meetingTeam,
+                                role = MeetingMemberRole.MEMBER
+                            )
+                        }
+                        launch(Dispatchers.Default) {
+                            meetingTeamDomainService.addMember(
+                                user = user2,
+                                meetingTeam = meetingTeam,
+                                role = MeetingMemberRole.MEMBER
+                            )
+                        }
+                    }
+                }
+
+                meetingTeamDomainService.countByMeetingTeamId(meetingTeam.id) shouldBe 2
+            }
+        }
+    }
+
+})


### PR DESCRIPTION
### 작업 내용

초대 링크를 통해 접속한 유저에 대해, 팀 초대 수락 가능 여부를 판별하기 위한 조회 API입니다.
초대 코드를 이용하여 미팅팀을 조회합니다.

### API
- **미팅 팀 입장 요청**
    - POST */api/meeting-teams/invitation/{invitationCode}*
        - request
            - method & path: `POST /api/meeting-teams/invitation/{invitationCode}`
            - body
                
                ```json
                --
                ```
                
        
        - response
            - 정상 처리된 경우
                - status code: `204 No-Content`
                - body

### PS
늦어서 죄송합니다ㅠㅠㅠ