### PR TITLE
[WEAV-000] Fix delete member apply published team cancel logic

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/CancelAllMeetingUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/CancelAllMeetingUseCase.kt
@@ -1,0 +1,10 @@
+package com.studentcenter.weave.application.meeting.port.inbound
+
+import java.util.*
+
+fun interface CancelAllMeetingUseCase {
+
+    fun invoke(command: Command)
+
+    data class Command(val teamId: UUID)
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingRepository.kt
@@ -22,4 +22,6 @@ interface MeetingRepository {
         receivingTeamId: UUID,
     ): Meeting?
 
+    fun cancelAllNotFinishedMeetingByTeamId(teamId: UUID)
+
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/CancelAllMeetingApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/CancelAllMeetingApplicationService.kt
@@ -1,0 +1,17 @@
+package com.studentcenter.weave.application.meeting.service.application
+
+import com.studentcenter.weave.application.meeting.port.inbound.CancelAllMeetingUseCase
+import com.studentcenter.weave.application.meeting.service.domain.MeetingDomainService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CancelAllMeetingApplicationService(
+    private val meetingDomainService: MeetingDomainService,
+) : CancelAllMeetingUseCase {
+
+    @Transactional
+    override fun invoke(command: CancelAllMeetingUseCase.Command) {
+        meetingDomainService.cancelAllNotFinishedMeetingByTeamId(command.teamId)
+    }
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingDomainService.kt
@@ -22,4 +22,6 @@ interface MeetingDomainService {
         receivingTeamId: UUID,
     ): Meeting?
 
+    fun cancelAllNotFinishedMeetingByTeamId(teamId: UUID)
+
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingDomainServiceImpl.kt
@@ -46,4 +46,8 @@ class MeetingDomainServiceImpl(
         )
     }
 
+    override fun cancelAllNotFinishedMeetingByTeamId(teamId: UUID) {
+        meetingRepository.cancelAllNotFinishedMeetingByTeamId(teamId)
+    }
+
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationService.kt
@@ -1,6 +1,7 @@
 package com.studentcenter.weave.application.meetingTeam.service.application
 
 import com.studentcenter.weave.application.common.security.context.getCurrentUserAuthentication
+import com.studentcenter.weave.application.meeting.port.inbound.CancelAllMeetingUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamLeaveUseCase
 import com.studentcenter.weave.application.meetingTeam.service.domain.MeetingTeamDomainService
 import org.springframework.stereotype.Service
@@ -9,13 +10,22 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class MeetingTeamLeaveApplicationService(
     private val meetingTeamDomainService: MeetingTeamDomainService,
+    private val cancelAllMeetingUseCase: CancelAllMeetingUseCase,
 ) : MeetingTeamLeaveUseCase {
 
     @Transactional
     override fun invoke(command: MeetingTeamLeaveUseCase.Command) {
-        getCurrentUserAuthentication()
-            .userId
-            .also { meetingTeamDomainService.deleteMember(it, command.meetingTeamId) }
+        val team = meetingTeamDomainService.getById(command.meetingTeamId)
+        if (team.isPublished().not()) {
+            meetingTeamDomainService.deleteMember(getCurrentUserAuthentication().userId, command.meetingTeamId)
+            return
+        }
+
+        // 팀이 공개된 상태라면
+        // 1. 연결된 모든 미팅 상태 취소 처리
+        // 2. 팀 삭제
+        cancelAllMeetingUseCase.invoke(CancelAllMeetingUseCase.Command(team.id))
+        meetingTeamDomainService.deleteById(team.id)
     }
 
 }

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationServiceTest.kt
@@ -2,6 +2,7 @@ package com.studentcenter.weave.application.meetingTeam.service.application
 
 import com.studentcenter.weave.application.common.exception.MeetingTeamExceptionType
 import com.studentcenter.weave.application.common.security.context.UserSecurityContext
+import com.studentcenter.weave.application.meeting.port.inbound.CancelAllMeetingUseCase
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingMemberRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamMemberSummaryRepositorySpy
 import com.studentcenter.weave.application.meetingTeam.outbound.MeetingTeamRepositorySpy
@@ -34,7 +35,11 @@ class MeetingTeamLeaveApplicationServiceTest : DescribeSpec({
         meetingTeamMemberSummaryRepository = meetingTeamMemberSummaryRepository,
         userQueryUseCase = userQueryUseCase,
     )
-    val sut = MeetingTeamLeaveApplicationService(meetingTeamDomainService)
+    val cancelAllMeetingUseCase = mockk<CancelAllMeetingUseCase>(relaxed = true)
+    val sut = MeetingTeamLeaveApplicationService(
+        meetingTeamDomainService = meetingTeamDomainService,
+        cancelAllMeetingUseCase = cancelAllMeetingUseCase,
+    )
 
     afterEach {
         meetingMemberRepository.clear()

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/MeetingTeamLeaveApplicationServiceTest.kt
@@ -20,6 +20,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
 import io.mockk.mockk
 
 @DisplayName("MeetingTeamLeaveApplicationService")
@@ -45,6 +46,7 @@ class MeetingTeamLeaveApplicationServiceTest : DescribeSpec({
         meetingMemberRepository.clear()
         meetingTeamRepository.clear()
         SecurityContextHolder.clearContext()
+        clearAllMocks()
     }
 
     describe("미팅팀 나가기 유스케이스") {

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingRepositorySpy.kt
@@ -47,6 +47,13 @@ class MeetingRepositorySpy : MeetingRepository {
         }
     }
 
+    override fun cancelAllNotFinishedMeetingByTeamId(teamId: UUID) {
+        bucket
+            .values
+            .filter { it.requestingTeamId == teamId || it.receivingTeamId == teamId }
+            .map { it.cancel() }
+    }
+
     fun findByRequestingMeetingTeamIdAndReceivingMeetingTeamId(
         requestingTeamId: UUID,
         receivingTeamId: UUID,

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingJpaAdapter.kt
@@ -60,4 +60,8 @@ class MeetingJpaAdapter(
             ?.toDomain()
     }
 
+    override fun cancelAllNotFinishedMeetingByTeamId(teamId: UUID) {
+        return meetingJpaRepository.cancelAllNotFinishedMeetingByTeamId(teamId)
+    }
+
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingJpaRepository.kt
@@ -1,7 +1,10 @@
 package com.studentcenter.weave.infrastructure.persistence.meeting.repository
 
+import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
 import com.studentcenter.weave.infrastructure.persistence.meeting.entity.MeetingJpaEntity
+import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
@@ -49,5 +52,15 @@ interface MeetingJpaRepository : JpaRepository<MeetingJpaEntity, UUID> {
         requestingTeamId: UUID,
         receivingTeamId: UUID,
     ): Optional<MeetingJpaEntity>
+
+
+    @Modifying
+    @Query(value = """
+        UPDATE meeting
+        SET status = 'CANCELED', finished_at = now()
+        WHERE (requesting_team_id = :teamId or receiving_team_id = :teamId)
+        AND status NOT IN ('COMPLETED', 'CANCELED') 
+    """, nativeQuery = true)
+    fun cancelAllNotFinishedMeetingByTeamId(@Param("teamId") teamId: UUID)
 
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingJpaRepository.kt
@@ -55,12 +55,15 @@ interface MeetingJpaRepository : JpaRepository<MeetingJpaEntity, UUID> {
 
 
     @Modifying
-    @Query(value = """
+    @Query(value =
+        """
         UPDATE meeting
         SET status = 'CANCELED', finished_at = now()
         WHERE (requesting_team_id = :teamId or receiving_team_id = :teamId)
         AND status NOT IN ('COMPLETED', 'CANCELED') 
-    """, nativeQuery = true)
+        """,
+        nativeQuery = true
+    )
     fun cancelAllNotFinishedMeetingByTeamId(@Param("teamId") teamId: UUID)
 
 }


### PR DESCRIPTION
## 작업 내용
- 팀이 공개된 상태에서 멤버가 나갈 경우 모든 완료되지 않은 미팅은 취소 처리되며 팀은 삭제처리합니다