### PR TITLE
[WEAV-276] 매칭된 팀 스크롤 조회

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/ScrollPreparedMeetingUseCase.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/ScrollPreparedMeetingUseCase.kt
@@ -1,0 +1,26 @@
+package com.studentcenter.weave.application.meeting.port.inbound
+
+import com.studentcenter.weave.application.meeting.vo.PreparedMeetingInfo
+import com.studentcenter.weave.support.common.dto.ScrollRequest
+import com.studentcenter.weave.support.common.dto.ScrollResponse
+import java.util.*
+
+fun interface ScrollPreparedMeetingUseCase {
+
+    fun invoke(command: Command) :Result
+
+    data class Command(
+        override val next: UUID?,
+        override val limit: Int,
+    ) : ScrollRequest<UUID?>(next, limit)
+
+    data class Result(
+        override val items: List<PreparedMeetingInfo>,
+        override val next: UUID?
+    ) : ScrollResponse<PreparedMeetingInfo, UUID?>(
+        items = items,
+        next = next,
+        total = items.size,
+    )
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingRepository.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingRepository.kt
@@ -26,4 +26,6 @@ interface MeetingRepository {
 
     fun existsMeetingRequest(requestingTeamId: UUID, receivingMeetingTeamId: UUID) : Boolean
 
+    fun findAllPreparedMeetingByTeamId(teamId: UUID, next: UUID?, limit: Int): List<Meeting>
+
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/ScrollPreparedMeetingApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/ScrollPreparedMeetingApplicationService.kt
@@ -1,0 +1,87 @@
+package com.studentcenter.weave.application.meeting.service.application
+
+import com.studentcenter.weave.application.common.exception.MeetingExceptionType
+import com.studentcenter.weave.application.common.security.context.getCurrentUserAuthentication
+import com.studentcenter.weave.application.meeting.port.inbound.ScrollPreparedMeetingUseCase
+import com.studentcenter.weave.application.meeting.service.domain.MeetingDomainService
+import com.studentcenter.weave.application.meeting.vo.PreparedMeetingInfo
+import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamInfoGetAllByIdUseCase
+import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamQueryUseCase
+import com.studentcenter.weave.domain.meeting.entity.Meeting
+import com.studentcenter.weave.support.common.exception.CustomException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+class ScrollPreparedMeetingApplicationService(
+    private val meetingDomainService: MeetingDomainService,
+    private val meetingTeamQueryUseCase: MeetingTeamQueryUseCase,
+    private val meetingTeamInfoGetAllByIdsUseCase: MeetingTeamInfoGetAllByIdUseCase,
+) : ScrollPreparedMeetingUseCase {
+
+    @Transactional(readOnly = true)
+    override fun invoke(command: ScrollPreparedMeetingUseCase.Command): ScrollPreparedMeetingUseCase.Result {
+        val myTeam = meetingTeamQueryUseCase.findByMemberUserId(getCurrentUserAuthentication().userId)
+            ?: throw CustomException(
+                MeetingExceptionType.NOT_FOUND_MY_MEETING_TEAM,
+                "내 미팅팀이 존재하지 않아요! 미팅팀에 참여해 주세요!",
+            )
+
+        val (items, next) = scrollByPreparedMeetingByTeamId(
+            teamId = myTeam.id,
+            next = command.next,
+            limit = command.limit,
+        )
+
+        return ScrollPreparedMeetingUseCase.Result(
+            items = createPreparedMeetingInfos(items, myTeam.id),
+            next = next,
+        )
+    }
+
+    private fun scrollByPreparedMeetingByTeamId(
+        teamId: UUID,
+        next: UUID?,
+        limit: Int,
+    ): Pair<List<Meeting>, UUID?> {
+        val meetings = meetingDomainService.findAllPreparedMeetingByTeamId(
+            teamId = teamId,
+            next = next,
+            limit = limit + 1,
+        )
+        val newNext = if (meetings.size > limit) meetings.last().id else null
+        val items = if (newNext == null) meetings else meetings.subList(0, limit)
+        return items to newNext
+    }
+
+    private fun createPreparedMeetingInfos(
+        items: List<Meeting>,
+        myTeamId: UUID,
+    ) : List<PreparedMeetingInfo> {
+        val teamIds = getUniqueTeamIds(items)
+        val teamIdToTeamInfo = mapTeamIdToTeamInfo(teamIds)
+
+        return items.map {
+            val otherTeamId = if (it.requestingTeamId != myTeamId) it.requestingTeamId else it.receivingTeamId
+            val otherTeamInfo = teamIdToTeamInfo[otherTeamId]
+                ?: throw IllegalArgumentException()
+            PreparedMeetingInfo(
+                id = it.id,
+                memberCount = otherTeamInfo.team.memberCount,
+                otherTeam = otherTeamInfo,
+                status = it.status,
+                createdAt = it.createdAt,
+            )
+        }
+    }
+
+    private fun mapTeamIdToTeamInfo(teamIds: List<UUID>) =
+        meetingTeamInfoGetAllByIdsUseCase.invoke(teamIds)
+            .associateBy { it.team.id }
+
+    private fun getUniqueTeamIds(items: List<Meeting>) = items
+            .flatMap { listOf(it.receivingTeamId, it.requestingTeamId) }
+            .distinct()
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingDomainService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingDomainService.kt
@@ -15,6 +15,12 @@ interface MeetingDomainService {
         limit: Int,
     ): List<Meeting>
 
+    fun findAllPreparedMeetingByTeamId(
+        teamId: UUID,
+        next: UUID?,
+        limit: Int,
+    ): List<Meeting>
+
     fun getById(id: UUID): Meeting
 
     fun findByRequestingTeamIdAndReceivingTeamId(

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingDomainServiceImpl.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/impl/MeetingDomainServiceImpl.kt
@@ -32,6 +32,18 @@ class MeetingDomainServiceImpl(
         )
     }
 
+    override fun findAllPreparedMeetingByTeamId(
+        teamId: UUID,
+        next: UUID?,
+        limit: Int,
+    ): List<Meeting> {
+        return meetingRepository.findAllPreparedMeetingByTeamId(
+            teamId = teamId,
+            next = next,
+            limit = limit,
+        )
+    }
+
     override fun getById(id: UUID): Meeting {
         return meetingRepository.getById(id)
     }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/vo/PreparedMeetingInfo.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/vo/PreparedMeetingInfo.kt
@@ -1,0 +1,14 @@
+package com.studentcenter.weave.application.meeting.vo
+
+import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInfo
+import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
+import java.time.LocalDateTime
+import java.util.*
+
+data class PreparedMeetingInfo(
+    val id: UUID,
+    val memberCount: Int,
+    val otherTeam: MeetingTeamInfo,
+    val status: MeetingStatus,
+    val createdAt: LocalDateTime,
+)

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/ScrollPendingMeetingApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/ScrollPendingMeetingApplicationServiceTest.kt
@@ -7,9 +7,8 @@ import com.studentcenter.weave.application.meeting.service.domain.impl.MeetingDo
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamInfoGetAllByIdUseCase
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamQueryUseCase
 import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInfo
-import com.studentcenter.weave.application.meetingTeam.vo.MemberInfo
 import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInfoCreator
-import com.studentcenter.weave.application.university.port.outbound.UniversityRepositorySpy
+import com.studentcenter.weave.application.meetingTeam.vo.MemberInfo
 import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.meeting.entity.MeetingFixtureFactory
 import com.studentcenter.weave.domain.meeting.enums.TeamType
@@ -23,6 +22,7 @@ import com.studentcenter.weave.domain.user.entity.User
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
 import com.studentcenter.weave.domain.user.enums.Gender
 import com.studentcenter.weave.support.common.exception.CustomException
+import com.studentcenter.weave.support.common.uuid.UuidCreator
 import com.studentcenter.weave.support.security.context.SecurityContextHolder
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
@@ -32,6 +32,8 @@ import io.kotest.matchers.shouldNotBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import kotlin.random.Random
+import kotlin.random.nextUInt
 
 @DisplayName("ScrollPendingMeetingApplicationServiceTest")
 class ScrollPendingMeetingApplicationServiceTest : DescribeSpec({

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/ScrollPendingMeetingApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/ScrollPendingMeetingApplicationServiceTest.kt
@@ -8,6 +8,7 @@ import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamI
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamQueryUseCase
 import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInfo
 import com.studentcenter.weave.application.meetingTeam.vo.MemberInfo
+import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInfoCreator
 import com.studentcenter.weave.application.university.port.outbound.UniversityRepositorySpy
 import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.meeting.entity.MeetingFixtureFactory
@@ -22,7 +23,6 @@ import com.studentcenter.weave.domain.user.entity.User
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
 import com.studentcenter.weave.domain.user.enums.Gender
 import com.studentcenter.weave.support.common.exception.CustomException
-import com.studentcenter.weave.support.common.uuid.UuidCreator
 import com.studentcenter.weave.support.security.context.SecurityContextHolder
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
@@ -32,8 +32,6 @@ import io.kotest.matchers.shouldNotBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import kotlin.random.Random
-import kotlin.random.nextUInt
 
 @DisplayName("ScrollPendingMeetingApplicationServiceTest")
 class ScrollPendingMeetingApplicationServiceTest : DescribeSpec({
@@ -50,8 +48,6 @@ class ScrollPendingMeetingApplicationServiceTest : DescribeSpec({
         meetingTeamQueryUseCase = meetingTeamQueryUseCase,
         meetingTeamInfoGetAllByIdsUseCase = meetingTeamInfoGetAllByIdsUseCase,
     )
-
-    val univRepo = UniversityRepositorySpy()
 
     afterEach {
         meetingRepositorySpy.clear()
@@ -112,10 +108,10 @@ class ScrollPendingMeetingApplicationServiceTest : DescribeSpec({
                         limit = limit,
                     )
 
-                    val myTeamInfo = createMeetingTeamInfo(users = listOf(user), memberCount = 2)
+                    val myTeamInfo = MeetingTeamInfoCreator.create(users = listOf(user), memberCount = 2)
                     val teamInfos = MutableList(1) { myTeamInfo }
                     repeat(limit + 1) {
-                        val teamInfo = createMeetingTeamInfo(gender = Gender.WOMAN)
+                        val teamInfo = MeetingTeamInfoCreator.create(gender = Gender.WOMAN)
                         teamInfos.add(teamInfo)
                         meetingRepositorySpy.save(
                             if (teamType == TeamType.REQUESTING) {
@@ -166,10 +162,10 @@ class ScrollPendingMeetingApplicationServiceTest : DescribeSpec({
                         limit = limit,
                     )
 
-                    val myTeamInfo = createMeetingTeamInfo(users = listOf(user), memberCount = 2)
+                    val myTeamInfo = MeetingTeamInfoCreator.create(users = listOf(user), memberCount = 2)
                     val teamInfos = MutableList(1) { myTeamInfo }
                     repeat(count) {
-                        val teamInfo = createMeetingTeamInfo(gender = Gender.WOMAN)
+                        val teamInfo = MeetingTeamInfoCreator.create(gender = Gender.WOMAN)
                         teamInfos.add(teamInfo)
                         meetingRepositorySpy.save(
                             if (teamType == TeamType.REQUESTING) {

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/ScrollPreparedMeetingApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/ScrollPreparedMeetingApplicationServiceTest.kt
@@ -1,0 +1,167 @@
+package com.studentcenter.weave.application.meeting.service.application
+
+import com.studentcenter.weave.application.common.security.context.UserSecurityContext
+import com.studentcenter.weave.application.meeting.outbound.MeetingRepositorySpy
+import com.studentcenter.weave.application.meeting.port.inbound.ScrollPreparedMeetingUseCase
+import com.studentcenter.weave.application.meeting.service.domain.impl.MeetingDomainServiceImpl
+import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamInfoGetAllByIdUseCase
+import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamQueryUseCase
+import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInfoCreator
+import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
+import com.studentcenter.weave.domain.meeting.entity.MeetingFixtureFactory
+import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
+import com.studentcenter.weave.domain.user.entity.User
+import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import com.studentcenter.weave.domain.user.enums.Gender
+import com.studentcenter.weave.support.common.exception.CustomException
+import com.studentcenter.weave.support.security.context.SecurityContextHolder
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+
+@DisplayName("ScrollPreparedMeetingApplicationServiceTest")
+class ScrollPreparedMeetingApplicationServiceTest : DescribeSpec({
+
+    val meetingRepositorySpy = MeetingRepositorySpy()
+    val meetingDomainService = MeetingDomainServiceImpl(
+        meetingRepository = meetingRepositorySpy,
+    )
+    val meetingTeamQueryUseCase = mockk<MeetingTeamQueryUseCase>()
+    val meetingTeamInfoGetAllByIdsUseCase = mockk<MeetingTeamInfoGetAllByIdUseCase>()
+
+    val sut = ScrollPreparedMeetingApplicationService(
+        meetingDomainService = meetingDomainService,
+        meetingTeamQueryUseCase = meetingTeamQueryUseCase,
+        meetingTeamInfoGetAllByIdsUseCase = meetingTeamInfoGetAllByIdsUseCase,
+    )
+
+    afterEach {
+        meetingRepositorySpy.clear()
+        SecurityContextHolder.clearContext()
+        clearAllMocks()
+    }
+
+    describe("미팅 준비 스크롤 유스케이스") {
+        context("내 미팅팀이 존재하지 않는 경우") {
+            it("예외가 발생한다") {
+                // arrange
+                val user = createUserAndSetAuthentication()
+                val command = ScrollPreparedMeetingUseCase.Command(
+                    next = null,
+                    limit = 20,
+                )
+                every { meetingTeamQueryUseCase.findByMemberUserId(user.id) } returns null
+
+                // act, assert
+                shouldThrow<CustomException> { sut.invoke(command) }
+            }
+        }
+
+        context("준비중인 미팅이 없는 경우") {
+            it("빈 리스트를 반환한다.") {
+                // arrange
+                val user = createUserAndSetAuthentication()
+                val limit = 2
+                val command = ScrollPreparedMeetingUseCase.Command(
+                    next = null,
+                    limit = limit,
+                )
+                every { meetingTeamQueryUseCase.findByMemberUserId(user.id) } returns MeetingTeamFixtureFactory.create()
+                every { meetingTeamInfoGetAllByIdsUseCase.invoke(any()) } returns emptyList()
+
+                // act
+                val result = sut.invoke(command)
+
+                // assert
+                result.items.isEmpty() shouldBe true
+                result.next shouldBe null
+                result.total shouldBe 0
+            }
+        }
+
+        context("매칭된 팀이 충분한 경우") {
+                it("limit 만큼 조회된다.") {
+                    // arrange
+                    val user = createUserAndSetAuthentication()
+                    val limit = 2
+                    val command = ScrollPreparedMeetingUseCase.Command(
+                        next = null,
+                        limit = limit,
+                    )
+
+                    val myTeamInfo = MeetingTeamInfoCreator.create(users = listOf(user), memberCount = 2)
+                    val teamInfos = MutableList(1) { myTeamInfo }
+                    repeat(limit + 1) {
+                        val teamInfo = MeetingTeamInfoCreator.create(gender = Gender.WOMAN)
+                        teamInfos.add(teamInfo)
+                        meetingRepositorySpy.save(
+                            MeetingFixtureFactory.create(
+                                requestingTeamId = myTeamInfo.team.id,
+                                receivingTeamId = teamInfo.team.id,
+                                status = MeetingStatus.COMPLETED,
+                            )
+                        )
+                    }
+
+                    every { meetingTeamQueryUseCase.findByMemberUserId(user.id) } returns myTeamInfo.team
+                    every { meetingTeamInfoGetAllByIdsUseCase.invoke(any()) } returns teamInfos
+
+                    // act
+                    val result = sut.invoke(command)
+
+                    // assert
+                    result.next shouldNotBe null
+                    result.total shouldBe limit
+                }
+            }
+        }
+
+        context("보낸 요청이 부족한 경우") {
+            it("데이터의 수만큼 조회된다") {
+                // arrange
+                val user = createUserAndSetAuthentication()
+                val limit = 3
+                val command = ScrollPreparedMeetingUseCase.Command(
+                    next = null,
+                    limit = limit,
+                )
+
+                val myTeamInfo = MeetingTeamInfoCreator.create(users = listOf(user), memberCount = 2)
+                val teamInfos = MutableList(1) { myTeamInfo }
+                repeat(limit - 1) {
+                    val teamInfo = MeetingTeamInfoCreator.create(gender = Gender.WOMAN)
+                    teamInfos.add(teamInfo)
+                    meetingRepositorySpy.save(
+                        MeetingFixtureFactory.create(
+                            requestingTeamId = myTeamInfo.team.id,
+                            receivingTeamId = teamInfo.team.id,
+                            status = MeetingStatus.COMPLETED,
+                        )
+                    )
+                }
+
+                every { meetingTeamQueryUseCase.findByMemberUserId(user.id) } returns myTeamInfo.team
+                every { meetingTeamInfoGetAllByIdsUseCase.invoke(any()) } returns teamInfos
+
+                // act
+                val result = sut.invoke(command)
+
+                // assert
+                result.next shouldBe null
+                result.total shouldBe limit - 1
+            }
+        }
+})
+
+private fun createUserAndSetAuthentication(): User {
+    return UserFixtureFactory.create().also {
+        val userAuthentication = UserAuthenticationFixtureFactory.create(it)
+        SecurityContextHolder.setContext(UserSecurityContext(userAuthentication))
+    }
+}

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingRepositorySpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingRepositorySpy.kt
@@ -2,6 +2,7 @@ package com.studentcenter.weave.application.meeting.outbound
 
 import com.studentcenter.weave.application.meeting.port.outbound.MeetingRepository
 import com.studentcenter.weave.domain.meeting.entity.Meeting
+import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
 import com.studentcenter.weave.domain.meeting.enums.TeamType
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -63,6 +64,20 @@ class MeetingRepositorySpy : MeetingRepository {
             .any {
                 it.requestingTeamId == requestingTeamId && it.receivingTeamId == receivingMeetingTeamId
             }
+    }
+
+    override fun findAllPreparedMeetingByTeamId(
+        teamId: UUID,
+        next: UUID?,
+        limit: Int,
+    ): List<Meeting> {
+        return bucket
+            .values
+            .filter {
+                // FIXME(prepared): 추후에 상태가 추가되면 Completed -> Prepared
+                (it.requestingTeamId == teamId || it.receivingTeamId == teamId)
+                        && it.status == MeetingStatus.COMPLETED
+            }.take(limit)
     }
 
     fun findByRequestingMeetingTeamIdAndReceivingMeetingTeamId(

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/vo/MeetingTeamInfoCreator.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/vo/MeetingTeamInfoCreator.kt
@@ -1,0 +1,63 @@
+package com.studentcenter.weave.application.meetingTeam.vo
+
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
+import com.studentcenter.weave.domain.meetingTeam.enums.MeetingMemberRole
+import com.studentcenter.weave.domain.meetingTeam.enums.MeetingTeamStatus
+import com.studentcenter.weave.domain.university.vo.UniversityName
+import com.studentcenter.weave.domain.user.entity.UniversityFixtureFactory
+import com.studentcenter.weave.domain.user.entity.User
+import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import com.studentcenter.weave.domain.user.enums.Gender
+import com.studentcenter.weave.support.common.uuid.UuidCreator
+import kotlin.random.Random
+import kotlin.random.nextUInt
+
+object MeetingTeamInfoCreator {
+    fun create(
+        users: List<User> = emptyList(),
+        memberCount: Int = 2,
+        gender: Gender = Gender.MAN,
+    ): MeetingTeamInfo {
+        val g = users.distinctBy { it.gender }
+        require(g.size <= 1) { "성별이 다른 멤버로 팀을 만들 수 없어요" }
+        require(users.isEmpty() || users[0].gender == gender ) { "멤버와 성별이 다를 수 없어요" }
+        val team = MeetingTeamFixtureFactory.create(
+            memberCount = memberCount,
+            status = MeetingTeamStatus.PUBLISHED,
+            gender = gender
+        )
+        val members = MutableList(users.size) { i ->
+            MeetingTeamInfo.MemberInfo(
+                id = UuidCreator.create(),
+                user = users[i],
+                university = UniversityFixtureFactory.create(
+                    id = users[i].universityId,
+                    name = UniversityName(value = "${Random.nextUInt()}대학교"),
+                ),
+                role = if (i == 0) MeetingMemberRole.LEADER else MeetingMemberRole.MEMBER
+            )
+        }
+
+        if (users.size < memberCount) {
+            repeat(memberCount - users.size) { i ->
+                val user = UserFixtureFactory.create(gender = gender)
+                members.add(
+                    MeetingTeamInfo.MemberInfo(
+                        id = UuidCreator.create(),
+                        user = user,
+                        university = UniversityFixtureFactory.create(
+                            id = user.universityId,
+                            name = UniversityName(value = "${Random.nextUInt()}대학교"),
+                        ),
+                        role = if (users.isEmpty() && i == 0) MeetingMemberRole.LEADER else MeetingMemberRole.MEMBER
+                    )
+                )
+            }
+        }
+
+        return MeetingTeamInfo(
+            team = team,
+            memberInfos = members
+        )
+    }
+}

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/vo/MeetingTeamInfoCreator.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meetingTeam/vo/MeetingTeamInfoCreator.kt
@@ -27,7 +27,7 @@ object MeetingTeamInfoCreator {
             gender = gender
         )
         val members = MutableList(users.size) { i ->
-            MeetingTeamInfo.MemberInfo(
+            MemberInfo(
                 id = UuidCreator.create(),
                 user = users[i],
                 university = UniversityFixtureFactory.create(
@@ -42,7 +42,7 @@ object MeetingTeamInfoCreator {
             repeat(memberCount - users.size) { i ->
                 val user = UserFixtureFactory.create(gender = gender)
                 members.add(
-                    MeetingTeamInfo.MemberInfo(
+                    MemberInfo(
                         id = UuidCreator.create(),
                         user = user,
                         university = UniversityFixtureFactory.create(

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/api/MeetingApi.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/api/MeetingApi.kt
@@ -8,6 +8,8 @@ import com.studentcenter.weave.bootstrap.meeting.dto.MeetingResponse
 import com.studentcenter.weave.bootstrap.meeting.dto.PendingMeetingScrollRequest
 import com.studentcenter.weave.bootstrap.meeting.dto.PendingMeetingScrollResponse
 import com.studentcenter.weave.domain.user.vo.KakaoId
+import com.studentcenter.weave.bootstrap.meeting.dto.PreparedMeetingScrollRequest
+import com.studentcenter.weave.bootstrap.meeting.dto.PreparedMeetingScrollResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.enums.ParameterIn
@@ -74,6 +76,14 @@ interface MeetingApi {
         @Parameter(description = "receiving team id", required = true, `in` = ParameterIn.QUERY)
         receivingTeamId: UUID,
     ) : MeetingResponse
+
+    @Secured
+    @Operation(summary = "Scroll prepared meetings")
+    @GetMapping("/status/prepared")
+    @ResponseStatus(HttpStatus.OK)
+    fun scrollPreparedMeetings(
+        request: PreparedMeetingScrollRequest,
+    ) : PreparedMeetingScrollResponse
 
     @Secured
     @Operation(summary = "Get other team member's kakao id by meeting id")

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingRestController.kt
@@ -6,6 +6,7 @@ import com.studentcenter.weave.application.meeting.port.inbound.GetMeetingAttend
 import com.studentcenter.weave.application.meeting.port.inbound.MeetingAttendanceCreateUseCase
 import com.studentcenter.weave.application.meeting.port.inbound.MeetingRequestUseCase
 import com.studentcenter.weave.application.meeting.port.inbound.ScrollPendingMeetingUseCase
+import com.studentcenter.weave.application.meeting.port.inbound.ScrollPreparedMeetingUseCase
 import com.studentcenter.weave.bootstrap.meeting.api.MeetingApi
 import com.studentcenter.weave.bootstrap.meeting.dto.KakaoIdResponse
 import com.studentcenter.weave.bootstrap.meeting.dto.MeetingAttendancesResponse
@@ -13,6 +14,8 @@ import com.studentcenter.weave.bootstrap.meeting.dto.MeetingRequestRequest
 import com.studentcenter.weave.bootstrap.meeting.dto.MeetingResponse
 import com.studentcenter.weave.bootstrap.meeting.dto.PendingMeetingScrollRequest
 import com.studentcenter.weave.bootstrap.meeting.dto.PendingMeetingScrollResponse
+import com.studentcenter.weave.bootstrap.meeting.dto.PreparedMeetingScrollRequest
+import com.studentcenter.weave.bootstrap.meeting.dto.PreparedMeetingScrollResponse
 import org.springframework.web.bind.annotation.RestController
 import java.util.*
 
@@ -20,6 +23,7 @@ import java.util.*
 class MeetingRestController(
     private val meetingRequestUseCase: MeetingRequestUseCase,
     private val scrollPendingMeetingUseCase: ScrollPendingMeetingUseCase,
+    private val scrollPreparedMeetingUseCase: ScrollPreparedMeetingUseCase,
     private val getMeetingAttendancesUseCase: GetMeetingAttendancesUseCase,
     private val meetingAttendanceCreateUseCase: MeetingAttendanceCreateUseCase,
     private val findMyRequestMeetingByReceivingTeamIdUseCase: FindMyRequestMeetingByReceivingTeamIdUseCase,
@@ -70,6 +74,16 @@ class MeetingRestController(
     override fun findMyRequestMeetingByReceivingTeamId(receivingTeamId: UUID) : MeetingResponse {
         return findMyRequestMeetingByReceivingTeamIdUseCase.invoke(receivingTeamId).let {
             MeetingResponse.from(it)
+        }
+    }
+
+    override fun scrollPreparedMeetings(request: PreparedMeetingScrollRequest): PreparedMeetingScrollResponse {
+        return scrollPreparedMeetingUseCase.invoke(request.toCommand()).let {
+            PreparedMeetingScrollResponse(
+                items = it.items.map(PreparedMeetingScrollResponse.MeetingDto::from),
+                next = it.next,
+                total = it.total
+            )
         }
     }
 

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/MeetingTeamDto.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/MeetingTeamDto.kt
@@ -1,0 +1,44 @@
+package com.studentcenter.weave.bootstrap.meeting.dto
+
+import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInfo
+import java.util.*
+
+
+data class MeetingTeamDto(
+    val id: UUID,
+    val teamIntroduce: String,
+    val memberCount: Int,
+    val gender: String,
+    val memberInfos: List<MeetingMemberDto>,
+) {
+    companion object {
+        fun from(info: MeetingTeamInfo): MeetingTeamDto {
+            return MeetingTeamDto(
+                id = info.team.id,
+                teamIntroduce = info.team.teamIntroduce.value,
+                memberCount = info.team.memberCount,
+                gender = info.team.gender.name,
+                memberInfos = info.memberInfos.map {
+                    MeetingMemberDto(
+                        id = it.id,
+                        userId = it.user.id,
+                        universityName = it.university.name.value,
+                        mbti = it.user.mbti.value,
+                        birthYear = it.user.birthYear.value,
+                        animalType = it.user.animalType?.name,
+                    )
+                }
+            )
+        }
+    }
+
+    data class MeetingMemberDto(
+        val id: UUID,
+        val userId: UUID,
+        val universityName: String,
+        val mbti: String,
+        val birthYear: Int,
+        val animalType: String?,
+    )
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/PendingMeetingScrollResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/PendingMeetingScrollResponse.kt
@@ -1,7 +1,6 @@
 package com.studentcenter.weave.bootstrap.meeting.dto
 
 import com.studentcenter.weave.application.meeting.vo.PendingMeetingInfo
-import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInfo
 import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
 import com.studentcenter.weave.domain.meeting.enums.TeamType
 import com.studentcenter.weave.support.common.dto.ScrollResponse
@@ -41,43 +40,5 @@ data class PendingMeetingScrollResponse(
             }
         }
     }
-
-    data class MeetingTeamDto(
-        val id: UUID,
-        val teamIntroduce: String,
-        val memberCount: Int,
-        val gender: String,
-        val memberInfos: List<MeetingMemberDto>,
-    ) {
-        companion object {
-            fun from(info: MeetingTeamInfo): MeetingTeamDto {
-                return MeetingTeamDto(
-                    id = info.team.id,
-                    teamIntroduce = info.team.teamIntroduce.value,
-                    memberCount = info.team.memberCount,
-                    gender = info.team.gender.name,
-                    memberInfos = info.memberInfos.map {
-                        MeetingMemberDto(
-                            id = it.id,
-                            userId = it.user.id,
-                            universityName = it.university.name.value,
-                            mbti = it.user.mbti.value,
-                            birthYear = it.user.birthYear.value,
-                            animalType = it.user.animalType?.name,
-                        )
-                    }
-                )
-            }
-        }
-    }
-
-    data class MeetingMemberDto(
-        val id: UUID,
-        val userId: UUID,
-        val universityName: String,
-        val mbti: String,
-        val birthYear: Int,
-        val animalType: String?,
-    )
 }
 

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/PreparedMeetingScrollRequest.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/PreparedMeetingScrollRequest.kt
@@ -1,0 +1,29 @@
+package com.studentcenter.weave.bootstrap.meeting.dto
+
+import com.studentcenter.weave.application.meeting.port.inbound.ScrollPendingMeetingUseCase
+import com.studentcenter.weave.application.meeting.port.inbound.ScrollPreparedMeetingUseCase
+import com.studentcenter.weave.support.common.dto.ScrollRequest
+import io.swagger.v3.oas.annotations.Parameter
+import org.springdoc.core.annotations.ParameterObject
+import java.util.*
+
+@ParameterObject
+data class PreparedMeetingScrollRequest(
+    @Parameter(required = false, description = "이전 요청의 마지막 item id, 최초 요청시 null")
+    override val next: UUID? = null,
+    @Parameter(required = false, description = "조회할 개수(Default 20)")
+    override val limit: Int = 20,
+) : ScrollRequest<UUID?>(
+    next = next,
+    limit = limit,
+) {
+
+    fun toCommand(): ScrollPreparedMeetingUseCase.Command {
+        return ScrollPreparedMeetingUseCase.Command(
+            next = this.next,
+            limit = this.limit,
+        )
+    }
+
+}
+

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/PreparedMeetingScrollRequest.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/PreparedMeetingScrollRequest.kt
@@ -1,6 +1,5 @@
 package com.studentcenter.weave.bootstrap.meeting.dto
 
-import com.studentcenter.weave.application.meeting.port.inbound.ScrollPendingMeetingUseCase
 import com.studentcenter.weave.application.meeting.port.inbound.ScrollPreparedMeetingUseCase
 import com.studentcenter.weave.support.common.dto.ScrollRequest
 import io.swagger.v3.oas.annotations.Parameter

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/PreparedMeetingScrollResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/PreparedMeetingScrollResponse.kt
@@ -1,0 +1,76 @@
+package com.studentcenter.weave.bootstrap.meeting.dto
+
+import com.studentcenter.weave.application.meeting.vo.PreparedMeetingInfo
+import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInfo
+import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
+import com.studentcenter.weave.support.common.dto.ScrollResponse
+import java.time.LocalDateTime
+import java.util.*
+
+data class PreparedMeetingScrollResponse(
+    override val items: List<MeetingDto>,
+    override val next: UUID?,
+    override val total: Int,
+) : ScrollResponse<PreparedMeetingScrollResponse.MeetingDto, UUID?>(
+    items = items,
+    next = next,
+    total = items.size,
+) {
+
+    data class MeetingDto(
+        val id: UUID,
+        val memberCount: Int,
+        val otherTeam: MeetingTeamDto,
+        val status: MeetingStatus,
+        val createdAt: LocalDateTime,
+    ) {
+        companion object {
+            fun from(meetingInfo: PreparedMeetingInfo) : MeetingDto {
+                return MeetingDto(
+                    id = meetingInfo.id,
+                    memberCount = meetingInfo.memberCount,
+                    otherTeam = MeetingTeamDto.from(meetingInfo.otherTeam),
+                    status = meetingInfo.status,
+                    createdAt = meetingInfo.createdAt,
+                )
+            }
+        }
+    }
+
+    data class MeetingTeamDto(
+        val id: UUID,
+        val teamIntroduce: String,
+        val memberCount: Int,
+        val gender: String,
+        val memberInfos: List<MeetingMemberDto>,
+    ) {
+        companion object {
+            fun from(info: MeetingTeamInfo) = MeetingTeamDto(
+                id = info.team.id,
+                teamIntroduce = info.team.teamIntroduce.value,
+                memberCount = info.team.memberCount,
+                gender = info.team.gender.name,
+                memberInfos = info.memberInfos.map {
+                    MeetingMemberDto(
+                        id = it.id,
+                        userId = it.user.id,
+                        universityName = it.university.name.value,
+                        mbti = it.user.mbti.value,
+                        birthYear = it.user.birthYear.value,
+                        animalType = it.user.animalType?.name,
+                    )
+                }
+            )
+        }
+    }
+
+    data class MeetingMemberDto(
+        val id: UUID,
+        val userId: UUID,
+        val universityName: String,
+        val mbti: String,
+        val birthYear: Int,
+        val animalType: String?,
+    )
+}
+

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/PreparedMeetingScrollResponse.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/dto/PreparedMeetingScrollResponse.kt
@@ -1,7 +1,6 @@
 package com.studentcenter.weave.bootstrap.meeting.dto
 
 import com.studentcenter.weave.application.meeting.vo.PreparedMeetingInfo
-import com.studentcenter.weave.application.meetingTeam.vo.MeetingTeamInfo
 import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
 import com.studentcenter.weave.support.common.dto.ScrollResponse
 import java.time.LocalDateTime
@@ -36,41 +35,5 @@ data class PreparedMeetingScrollResponse(
             }
         }
     }
-
-    data class MeetingTeamDto(
-        val id: UUID,
-        val teamIntroduce: String,
-        val memberCount: Int,
-        val gender: String,
-        val memberInfos: List<MeetingMemberDto>,
-    ) {
-        companion object {
-            fun from(info: MeetingTeamInfo) = MeetingTeamDto(
-                id = info.team.id,
-                teamIntroduce = info.team.teamIntroduce.value,
-                memberCount = info.team.memberCount,
-                gender = info.team.gender.name,
-                memberInfos = info.memberInfos.map {
-                    MeetingMemberDto(
-                        id = it.id,
-                        userId = it.user.id,
-                        universityName = it.university.name.value,
-                        mbti = it.user.mbti.value,
-                        birthYear = it.user.birthYear.value,
-                        animalType = it.user.animalType?.name,
-                    )
-                }
-            )
-        }
-    }
-
-    data class MeetingMemberDto(
-        val id: UUID,
-        val userId: UUID,
-        val universityName: String,
-        val mbti: String,
-        val birthYear: Int,
-        val animalType: String?,
-    )
 }
 

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingJpaAdapter.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/adapter/MeetingJpaAdapter.kt
@@ -74,4 +74,16 @@ class MeetingJpaAdapter(
         )
     }
 
+    override fun findAllPreparedMeetingByTeamId(
+        teamId: UUID,
+        next: UUID?,
+        limit: Int,
+    ): List<Meeting> {
+        return meetingJpaRepository.findAllPreparedMeetings(
+            teamId = teamId,
+            next = next,
+            limit = limit,
+        ).map { it.toDomain() }
+    }
+
 }

--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingJpaRepository.kt
@@ -71,4 +71,22 @@ interface MeetingJpaRepository : JpaRepository<MeetingJpaEntity, UUID> {
         receivingMeetingTeamId: UUID,
     ): Boolean
 
+
+    // FIXME(prepared): 추후에 상태가 추가되면 Completed -> Prepared
+    @Query(
+        value = """
+            SELECT m.*
+            FROM meeting as m
+            WHERE (m.requesting_team_id = :teamId or m.receiving_team_id = :teamId)
+            AND (:next is null or id < :next)
+            AND m.status = 'COMPLETED'
+            LIMIT :limit
+        """,
+        nativeQuery = true
+    )
+    fun findAllPreparedMeetings(
+        @Param("teamId") teamId: UUID,
+        @Param("next") next: UUID?,
+        @Param("limit") limit: Int,
+    ): List<MeetingJpaEntity>
 }


### PR DESCRIPTION
## 작업 내용
- 매칭된 팀 스크롤 조회 구현 및 테스트
- 팀 인포 생성 오브젝트 분리
- 이후 미팅 상태 확장 시 코드 수정을 위한 주석