### PR TITLE
[WEAV-293]  🚀 HeadVer 버전 시스템 태그 생성 수정 및 GitHub 릴리스 자동화

### DIFF
--- a/.github/workflows/develop_server_integrator.yaml
+++ b/.github/workflows/develop_server_integrator.yaml
@@ -60,10 +60,23 @@ jobs:
           docker build -f Dockerfile-http -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG .
           docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
 
-      - name: Create Git tag
-        run: |
-          git tag ${{ steps.generate_version.outputs.version }}
-          git push origin ${{ steps.generate_version.outputs.version }}
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.generate_version.outputs.version }}
+          release_name: Release ${{ steps.generate_version.outputs.version }}
+          body: |
+            HeadVer 버전: ${{ steps.generate_version.outputs.version }}
+            - head: ${{ github.event.inputs.head }}
+            - yearweek: ${{ steps.generate_version.outputs.version.split('.')[1] }}
+            - build: ${{ steps.generate_version.outputs.version.split('.')[2] }}
+
+            ## 📝변경 사항
+            ${{ steps.generate_changelog.outputs.changelog }}
+          draft: false
+          prerelease: false
 
       - name: Logout of Amazon ECR
         run: docker logout ${{ env.ECR_REGISTRY }}


### PR DESCRIPTION
## 🚀 HeadVer 버전 시스템 태그 생성 수정 및 GitHub 릴리스 자동화

이 Pull Request는 기존의 HeadVer 버전 시스템을 개선하고 GitHub 릴리스 생성을 자동화하는 내용을 포함합니다. 주요 변경 사항은 다음과 같습니다:

### 🎯 주요 변경 사항

- Git 태그 생성 및 푸시를 "Create Release" 액션으로 대체하여 GitHub 릴리스 생성을 자동화합니다.
- 릴리스 노트에 HeadVer 버전 정보와 함께 해당 릴리스에 포함된 커밋의 변경 사항을 포함시킵니다.
- `generate_changelog` 단계를 추가하여 이전 릴리스부터 현재 릴리스까지의 커밋 메시지를 기반으로 변경 로그를 생성합니다.

### 🛠️ 구현 세부 사항

- "Create Release" 액션을 사용하여 GitHub 릴리스를 자동으로 생성합니다.
  - `GITHUB_TOKEN` 시크릿을 환경 변수로 설정하여 액션에서 사용할 수 있도록 합니다.
  - `tag_name`은 생성된 HeadVer 버전을 사용합니다.
  - `release_name`은 "Release" 접두사와 HeadVer 버전을 사용합니다.
  - `body`에는 HeadVer 버전의 세부 정보와 변경 로그를 포함합니다.
- `generate_changelog` 단계에서는 `git log` 명령어를 사용하여 이전 릴리스부터 현재 릴리스까지의 커밋 메시지를 가져와 변경 로그를 생성합니다.
  - 이전 릴리스 태그는 `git describe` 명령어를 사용하여 가져옵니다.
  - 현재 릴리스 태그는 `steps.generate_version.outputs.version`을 사용합니다.
  - 생성된 변경 로그는 `steps.generate_changelog.outputs.changelog`로 출력됩니다.

### 🌟 기대 효과

- GitHub 릴리스 생성이 자동화되어 릴리스 관리가 간편해집니다.
- 릴리스 노트에 HeadVer 버전 정보와 커밋 변경 사항이 포함되어 릴리스에 대한 상세 정보를 쉽게 파악할 수 있습니다.
- 변경 로그 생성이 자동화되어 수동으로 관리할 필요가 없어집니다.

### 🔍 릴리스 노트 예시


```markdown
HeadVer 버전: 1.2305.123
- head: 1
- yearweek: 2305
- build: 123

## 변경 사항
- 새로운 기능 추가
- 버그 수정
- 성능 개선
```