### PR TITLE
[WEAV-000] 정적 리소스 요청 stacktrace 로그 제거

### DIFF
--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/UnknownExceptionHandler.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/UnknownExceptionHandler.kt
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
-import org.springframework.web.servlet.NoHandlerFoundException
+import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @Hidden
 @RestControllerAdvice
@@ -20,14 +20,20 @@ class UnknownExceptionHandler {
     private val logger = KotlinLogging.logger { }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    @ExceptionHandler(NoHandlerFoundException::class)
+    @ExceptionHandler(NoResourceFoundException::class)
     fun handleNoHandlerFoundException(
-        e: NoHandlerFoundException,
+        e: NoResourceFoundException,
         request: HttpServletRequest
     ): ErrorResponse {
+        val requestMethod: String = request.method
+        val requestUrl: String = request.requestURI
+        val clientIp: String = request.getHeader("X-Forwarded-For") ?: request.remoteAddr
+
+        logger.warn { "NoResourceFoundException: $requestMethod $requestUrl from $clientIp" }
+
         return ErrorResponse(
             exceptionCode = SystemExceptionType.NOT_FOUND.code,
-            message = "No handler found for ${e.httpMethod} ${e.requestURL}"
+            message = "Not Found"
         )
     }
 

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/UnknownExceptionHandler.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/common/exception/UnknownExceptionHandler.kt
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.NoHandlerFoundException
 
 @Hidden
 @RestControllerAdvice
@@ -17,6 +18,18 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 class UnknownExceptionHandler {
 
     private val logger = KotlinLogging.logger { }
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NoHandlerFoundException::class)
+    fun handleNoHandlerFoundException(
+        e: NoHandlerFoundException,
+        request: HttpServletRequest
+    ): ErrorResponse {
+        return ErrorResponse(
+            exceptionCode = SystemExceptionType.NOT_FOUND.code,
+            message = "No handler found for ${e.httpMethod} ${e.requestURL}"
+        )
+    }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Throwable::class)

--- a/bootstrap/http/src/main/resources/application.yaml
+++ b/bootstrap/http/src/main/resources/application.yaml
@@ -11,6 +11,9 @@ spring:
       - redis
       - mail
       - aws
+  web:
+    resources:
+      add-mappings: false
 ---
 spring:
   config:

--- a/bootstrap/http/src/main/resources/application.yaml
+++ b/bootstrap/http/src/main/resources/application.yaml
@@ -11,9 +11,6 @@ spring:
       - redis
       - mail
       - aws
-  web:
-    resources:
-      add-mappings: false
 ---
 spring:
   config:

--- a/infrastructure/persistence/src/main/resources/application-persistence.yaml
+++ b/infrastructure/persistence/src/main/resources/application-persistence.yaml
@@ -54,6 +54,6 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
       ddl-auto: create-drop
-    show-sql: true
+    show-sql: false
   flyway:
     enabled: false

--- a/support/common/src/main/kotlin/com/studentcenter/weave/support/common/exception/SystemExceptionType.kt
+++ b/support/common/src/main/kotlin/com/studentcenter/weave/support/common/exception/SystemExceptionType.kt
@@ -2,5 +2,6 @@ package com.studentcenter.weave.support.common.exception
 
 enum class SystemExceptionType(override val code: String) : CustomExceptionType {
     INTERNAL_SERVER_ERROR("SYSTEM-000"),
-    RUNTIME_EXCEPTION("SYSTEM-001")
+    RUNTIME_EXCEPTION("SYSTEM-001"),
+    NOT_FOUND("SYSTEM-002"),
 }


### PR DESCRIPTION
- 악의적인 정적 리소스 요청으로 인해 로그 파악이 힘든점을 개선하기위해 정적 리소스 요청 리소스 매핑을 불가능하도록 하고, NoHandlerException에 대한 핸들링을 추가했습니다.
- integration 테스트시 sql 로깅을 제거해 테스트시 로그파악이 쉽도록 개선했습니다.