### PR TITLE
[WEAV-000]Fix all expired pending meeting cancel query

### DIFF
--- a/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingJpaRepository.kt
+++ b/infrastructure/persistence/src/main/kotlin/com/studentcenter/weave/infrastructure/persistence/meeting/repository/MeetingJpaRepository.kt
@@ -97,9 +97,8 @@ interface MeetingJpaRepository : JpaRepository<MeetingJpaEntity, UUID> {
     @Query("""
         UPDATE meeting m
         SET m.status = 'CANCELED', m.finished_at = DATE_ADD(m.created_at, INTERVAL 3 DAY) 
-        WHERE DATE_SUB(now(), INTERVAL 4 DAY) < m.created_at 
-        AND m.created_at <= DATE_SUB(now(), INTERVAL 3 DAY) 
-        AND m.status = 'PENDING' 
+        WHERE m.created_at <= DATE_SUB(now(), INTERVAL 3 DAY)
+        AND m.status = 'PENDING';
     """,
     nativeQuery = true)
     fun cancelEndedPendingMeeting()


### PR DESCRIPTION
## 작업 내용
- 생성 일자의 하한 제거


## 고민
- 풀스캔이라 인덱스 추가할까? 하한이 없으면 어차피 풀스캔이랑 다를바 없지 않을까?