### PR TITLE
[WEAV-000] isUserUniversityVerified 메서드 제거, User객체로 직접 확인하는 방식으로 변경

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingRequestApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingRequestApplicationService.kt
@@ -74,10 +74,10 @@ class MeetingRequestApplicationService(
     }
 
     private fun validateMyUniversityEmailVerified() {
-        val isUniversityEmailVerified = getCurrentUserAuthentication()
-            .let { getUser.isUserUniversityVerified(it.userId) }
+        val user = getCurrentUserAuthentication()
+            .let { getUser.getById(it.userId) }
 
-        if (isUniversityEmailVerified.not()){
+        if (user.isUnivVerified.not()){
             throw CustomException(
                 MeetingExceptionType.CAN_NOT_MEETING_REQUEST_NOT_UNIV_VERIFIED_USER,
                 "대학교 이메일 인증이 되지 않았어요! 대학교 이메일을 인증해 주세요!",

--- a/application/src/main/kotlin/com/studentcenter/weave/application/user/port/inbound/GetUser.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/user/port/inbound/GetUser.kt
@@ -7,6 +7,4 @@ interface GetUser {
 
     fun getById(id: UUID): User
 
-    fun isUserUniversityVerified(userId: UUID): Boolean
-
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/user/service/application/GetUserService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/user/service/application/GetUserService.kt
@@ -2,7 +2,6 @@ package com.studentcenter.weave.application.user.service.application
 
 import com.studentcenter.weave.application.user.port.inbound.GetUser
 import com.studentcenter.weave.application.user.service.domain.UserDomainService
-import com.studentcenter.weave.application.user.service.domain.UserUniversityVerificationInfoDomainService
 import com.studentcenter.weave.domain.user.entity.User
 import org.springframework.stereotype.Service
 import java.util.*
@@ -10,15 +9,10 @@ import java.util.*
 @Service
 class GetUserService(
     private val userDomainService: UserDomainService,
-    private val userUniversityVerificationInfoDomainService: UserUniversityVerificationInfoDomainService,
 ) : GetUser {
 
     override fun getById(id: UUID): User {
         return userDomainService.getById(id)
-    }
-
-    override fun isUserUniversityVerified(userId: UUID): Boolean {
-        return userUniversityVerificationInfoDomainService.existsByUserId(userId)
     }
 
 }

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingRequestApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingRequestApplicationServiceTest.kt
@@ -8,12 +8,12 @@ import com.studentcenter.weave.application.meeting.service.domain.impl.MeetingAt
 import com.studentcenter.weave.application.meeting.service.domain.impl.MeetingDomainServiceImpl
 import com.studentcenter.weave.application.meetingTeam.port.inbound.MeetingTeamQueryUseCase
 import com.studentcenter.weave.application.user.port.inbound.GetUser
-import com.studentcenter.weave.application.user.vo.UserAuthentication
 import com.studentcenter.weave.application.user.vo.UserAuthenticationFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingMemberFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeam
 import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
 import com.studentcenter.weave.domain.meetingTeam.enums.MeetingTeamStatus
+import com.studentcenter.weave.domain.user.entity.User
 import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
 import com.studentcenter.weave.domain.user.enums.Gender
 import com.studentcenter.weave.support.common.exception.CustomException
@@ -60,13 +60,12 @@ class MeetingRequestApplicationServiceTest : DescribeSpec({
             it("예외가 발생한다") {
                 // arrange
                 val receivingMeetingTeamId: UUID = UuidCreator.create()
-                val userAuthentication: UserAuthentication = UserFixtureFactory
-                    .create()
-                    .let { UserAuthenticationFixtureFactory.create(it) }
+                val user: User = UserFixtureFactory.create(isUnivVerified = true)
+                user.let { UserAuthenticationFixtureFactory.create(it) }
                     .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
 
-                every { getUser.isUserUniversityVerified(userAuthentication.userId) } returns true
-                every { meetingTeamQueryUseCase.findByMemberUserId(userAuthentication.userId) } returns null
+                every { getUser.getById(user.id) } returns user
+                every { meetingTeamQueryUseCase.findByMemberUserId(user.id) } returns null
 
                 // act, assert
                 shouldThrow<CustomException> {
@@ -86,13 +85,12 @@ class MeetingRequestApplicationServiceTest : DescribeSpec({
                     val receivingMeetingTeam: MeetingTeam =
                         MeetingTeamFixtureFactory.create(gender = gender)
 
-                    val userAuthentication: UserAuthentication = UserFixtureFactory
-                        .create()
-                        .let { UserAuthenticationFixtureFactory.create(it) }
+                    val user: User = UserFixtureFactory.create(isUnivVerified = true)
+                    user.let { UserAuthenticationFixtureFactory.create(it) }
                         .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
 
-                    every { getUser.isUserUniversityVerified(userAuthentication.userId) } returns true
-                    every { meetingTeamQueryUseCase.findByMemberUserId(userAuthentication.userId) } returns myMeetingTeam
+                    every { getUser.getById(user.id) } returns user
+                    every { meetingTeamQueryUseCase.findByMemberUserId(user.id) } returns myMeetingTeam
                     every { meetingTeamQueryUseCase.getById(receivingMeetingTeam.id) } returns receivingMeetingTeam
 
                     // act, assert
@@ -111,13 +109,12 @@ class MeetingRequestApplicationServiceTest : DescribeSpec({
                 val myMeetingTeam = MeetingTeamFixtureFactory.create(memberCount = 2)
                 val receivingMeetingTeam = MeetingTeamFixtureFactory.create(memberCount = 3)
 
-                val userAuthentication: UserAuthentication = UserFixtureFactory
-                    .create()
-                    .let { UserAuthenticationFixtureFactory.create(it) }
+                val user: User = UserFixtureFactory.create(isUnivVerified = true)
+                user.let { UserAuthenticationFixtureFactory.create(it) }
                     .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
 
-                every { getUser.isUserUniversityVerified(userAuthentication.userId) } returns true
-                every { meetingTeamQueryUseCase.findByMemberUserId(userAuthentication.userId) } returns myMeetingTeam
+                every { getUser.getById(user.id) } returns user
+                every { meetingTeamQueryUseCase.findByMemberUserId(user.id) } returns myMeetingTeam
                 every { meetingTeamQueryUseCase.getById(receivingMeetingTeam.id) } returns receivingMeetingTeam
 
                 // act, assert
@@ -136,13 +133,12 @@ class MeetingRequestApplicationServiceTest : DescribeSpec({
                     MeetingTeamFixtureFactory.create(status = MeetingTeamStatus.WAITING)
                 val receivingMeetingTeam = MeetingTeamFixtureFactory.create()
 
-                val userAuthentication: UserAuthentication = UserFixtureFactory
-                    .create()
-                    .let { UserAuthenticationFixtureFactory.create(it) }
+                val user: User = UserFixtureFactory.create(isUnivVerified = true)
+                user.let { UserAuthenticationFixtureFactory.create(it) }
                     .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
 
-                every { getUser.isUserUniversityVerified(userAuthentication.userId) } returns true
-                every { meetingTeamQueryUseCase.findByMemberUserId(userAuthentication.userId) } returns myMeetingTeam
+                every { getUser.getById(user.id) } returns user
+                every { meetingTeamQueryUseCase.findByMemberUserId(user.id) } returns myMeetingTeam
                 every { meetingTeamQueryUseCase.getById(receivingMeetingTeam.id) } returns receivingMeetingTeam
 
                 // act, assert
@@ -160,12 +156,11 @@ class MeetingRequestApplicationServiceTest : DescribeSpec({
                 val myMeetingTeam = MeetingTeamFixtureFactory.create()
                 val receivingMeetingTeam = MeetingTeamFixtureFactory.create()
 
-                val userAuthentication: UserAuthentication = UserFixtureFactory
-                    .create()
-                    .let { UserAuthenticationFixtureFactory.create(it) }
+                val user: User = UserFixtureFactory.create(isUnivVerified = false)
+                user.let { UserAuthenticationFixtureFactory.create(it) }
                     .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
 
-                every { getUser.isUserUniversityVerified(userAuthentication.userId) } returns false
+                every { getUser.getById(user.id) } returns user
 
                 // act, assert
                 shouldThrow<CustomException> {
@@ -188,16 +183,15 @@ class MeetingRequestApplicationServiceTest : DescribeSpec({
                     status = MeetingTeamStatus.PUBLISHED
                 )
 
-                val userAuthentication: UserAuthentication = UserFixtureFactory
-                    .create()
-                    .let { UserAuthenticationFixtureFactory.create(it) }
+                val user: User = UserFixtureFactory.create(isUnivVerified = true)
+                user.let { UserAuthenticationFixtureFactory.create(it) }
                     .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
 
-                every { getUser.isUserUniversityVerified(userAuthentication.userId) } returns true
-                every { meetingTeamQueryUseCase.findByMemberUserId(userAuthentication.userId) } returns myMeetingTeam
+                every { getUser.getById(user.id) } returns user
+                every { meetingTeamQueryUseCase.findByMemberUserId(user.id) } returns myMeetingTeam
                 every { meetingTeamQueryUseCase.getById(receivingMeetingTeam.id) } returns receivingMeetingTeam
                 every { meetingTeamQueryUseCase.findAllMeetingMembersByMeetingTeamId(any()) } returns
-                        listOf(MeetingMemberFixtureFactory.create(userId = userAuthentication.userId))
+                        listOf(MeetingMemberFixtureFactory.create(userId = user.id))
 
                 val command = MeetingRequestUseCase.Command(receivingMeetingTeam.id)
                 meetingRequestApplicationService.invoke(command)
@@ -220,16 +214,15 @@ class MeetingRequestApplicationServiceTest : DescribeSpec({
                     status = MeetingTeamStatus.PUBLISHED
                 )
 
-                val userAuthentication: UserAuthentication = UserFixtureFactory
-                    .create()
-                    .let { UserAuthenticationFixtureFactory.create(it) }
+                val user: User = UserFixtureFactory.create(isUnivVerified = true)
+                user.let { UserAuthenticationFixtureFactory.create(it) }
                     .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
 
-                every { getUser.isUserUniversityVerified(userAuthentication.userId) } returns true
-                every { meetingTeamQueryUseCase.findByMemberUserId(userAuthentication.userId) } returns myMeetingTeam
+                every { getUser.getById(user.id) } returns user
+                every { meetingTeamQueryUseCase.findByMemberUserId(user.id) } returns myMeetingTeam
                 every { meetingTeamQueryUseCase.getById(receivingMeetingTeam.id) } returns receivingMeetingTeam
                 every { meetingTeamQueryUseCase.findAllMeetingMembersByMeetingTeamId(any()) } returns
-                        listOf(MeetingMemberFixtureFactory.create(userId = userAuthentication.userId))
+                        listOf(MeetingMemberFixtureFactory.create(userId = user.id))
 
                 // act
                 MeetingRequestUseCase.Command(receivingMeetingTeam.id)
@@ -254,16 +247,15 @@ class MeetingRequestApplicationServiceTest : DescribeSpec({
                     status = MeetingTeamStatus.PUBLISHED
                 )
 
-                val userAuthentication: UserAuthentication = UserFixtureFactory
-                    .create()
-                    .let { UserAuthenticationFixtureFactory.create(it) }
+                val user: User = UserFixtureFactory.create(isUnivVerified = true)
+                user.let { UserAuthenticationFixtureFactory.create(it) }
                     .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
 
-                every { getUser.isUserUniversityVerified(userAuthentication.userId) } returns true
-                every { meetingTeamQueryUseCase.findByMemberUserId(userAuthentication.userId) } returns myMeetingTeam
+                every { getUser.getById(user.id) } returns user
+                every { meetingTeamQueryUseCase.findByMemberUserId(user.id) } returns myMeetingTeam
                 every { meetingTeamQueryUseCase.getById(receivingMeetingTeam.id) } returns receivingMeetingTeam
                 every { meetingTeamQueryUseCase.findAllMeetingMembersByMeetingTeamId(any()) } returns
-                        listOf(MeetingMemberFixtureFactory.create(userId = userAuthentication.userId))
+                        listOf(MeetingMemberFixtureFactory.create(userId = user.id))
 
                 // act
                 MeetingRequestUseCase.Command(receivingMeetingTeam.id)

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/user/port/inbound/GetUserStub.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/user/port/inbound/GetUserStub.kt
@@ -10,8 +10,4 @@ class GetUserStub : GetUser {
         return UserFixtureFactory.create(id = id)
     }
 
-    override fun isUserUniversityVerified(userId: UUID): Boolean {
-        return true
-    }
-
 }

--- a/domain/src/testFixtures/kotlin/com/studentcenter/weave/domain/user/entity/UserFixtureFactory.kt
+++ b/domain/src/testFixtures/kotlin/com/studentcenter/weave/domain/user/entity/UserFixtureFactory.kt
@@ -25,6 +25,7 @@ object UserFixtureFactory {
         height: Height? = null,
         animalType: AnimalType? = null,
         kakaoId: KakaoId? = null,
+        isUnivVerified: Boolean = false,
     ): User {
         return User(
             id = id,
@@ -38,6 +39,7 @@ object UserFixtureFactory {
             height = height,
             animalType = animalType,
             kakaoId = kakaoId,
+            isUnivVerified = isUnivVerified,
         )
     }
 


### PR DESCRIPTION
- 이메일 인증처리가 완료된경우 User의 isUnivVerified가 true가 되므로, userUniversityVerificationInfo의 존재여부를 조회하는것이 아닌 User를 쿼리해 내용을 확인하는방식으로 변경
- isUserUniversityVerified 메서드 제거, User객체로 직접 확인하는 방식으로 변경