### PR TITLE
[WEAV-000] 미팅 요청 validation 순서 조정

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingRequestApplicationService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingRequestApplicationService.kt
@@ -26,14 +26,13 @@ class MeetingRequestApplicationService(
 
     @Transactional
     override fun invoke(command: MeetingRequestUseCase.Command) {
-        validateMyUniversityEmailVerified()
-
         val myMeetingTeam: MeetingTeam = getMyMeetingTeam()
             .also {
                 validateMyMeetingTeamStatus(it)
                 validateDuplicatedRequest(it, command.receivingMeetingTeamId)
             }
 
+        validateMyUniversityEmailVerified()
 
         val receivingMeetingTeam: MeetingTeam =
             getMeetingTeam.getById(command.receivingMeetingTeamId)

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingRequestApplicationServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/MeetingRequestApplicationServiceTest.kt
@@ -160,6 +160,8 @@ class MeetingRequestApplicationServiceTest : DescribeSpec({
                     .also { SecurityContextHolder.setContext(UserSecurityContext(it)) }
 
                 every { getUser.getById(user.id) } returns user
+                every { getMeetingTeam.findByMemberUserId(user.id) } returns
+                        MeetingTeamFixtureFactory.create(status = MeetingTeamStatus.PUBLISHED)
 
                 // act, assert
                 shouldThrow<CustomException> {


### PR DESCRIPTION
현재 validation순서가

1. 대학교 인증을 했는가?
2. 내팀이 있는가?

순서로 진행이 되는데, 대학교 인증이 되지 않은경우에도 팀을 만들수 있긴 하기때문에,

1. 내팀이 있는가?
2. 대학교 인증을 했는가?

순서로 진행되어야한다는 클라이언트 의견을 반영

