### PR TITLE
[WEAV-331] 미팅 매칭시 채팅방 생성

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/CreateMeetingAttendance.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/CreateMeetingAttendance.kt
@@ -2,7 +2,7 @@ package com.studentcenter.weave.application.meeting.port.inbound
 
 import java.util.*
 
-fun interface MeetingAttendanceCreateUseCase {
+fun interface CreateMeetingAttendance {
 
     fun invoke(meetingId: UUID, attendance: Boolean)
 

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingEventPublisher.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingEventPublisher.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.application.meeting.port.outbound
+
+import com.studentcenter.weave.domain.meeting.event.MeetingCompletedEvent
+
+interface MeetingEventPublisher {
+
+    fun publish(meetingCompletedEvent: MeetingCompletedEvent)
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/CreateMeetingAttendanceService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/CreateMeetingAttendanceService.kt
@@ -99,9 +99,10 @@ class CreateMeetingAttendanceService(
     ) {
         meeting
             .complete()
-            .also { meetingDomainService.save(it) }
-            .createCompletedEvent()
-            .also { meetingEventPublisher.publish(it) }
+            .also {
+                meetingDomainService.save(it)
+                meetingEventPublisher.publish(it.createCompletedEvent())
+            }
 
         val matchedMeetingCount = meetingDomainService.countByStatusIsCompleted()
 

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingEventService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/domain/MeetingEventService.kt
@@ -1,0 +1,17 @@
+package com.studentcenter.weave.application.meeting.service.domain
+
+import com.studentcenter.weave.application.meeting.port.outbound.MeetingEventPublisher
+import com.studentcenter.weave.domain.meeting.event.MeetingCompletedEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+
+@Service
+class MeetingEventService(
+    private val eventPublisher: ApplicationEventPublisher,
+): MeetingEventPublisher {
+
+    override fun publish(meetingCompletedEvent: MeetingCompletedEvent) {
+        eventPublisher.publishEvent(meetingCompletedEvent)
+    }
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingEventHandler.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingEventHandler.kt
@@ -1,0 +1,20 @@
+package com.studentcenter.weave.bootstrap.meeting.controller
+
+import com.studentcenter.weave.application.chat.port.inbound.CreateChatRoom
+import com.studentcenter.weave.domain.meeting.event.MeetingCompletedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Controller
+
+@Controller
+class MeetingEventHandler(
+    private val createChatRoom: CreateChatRoom,
+) {
+
+    @EventListener
+    fun handleMeetingEvent(meetingCompletedEvent: MeetingCompletedEvent) {
+        meetingCompletedEvent
+            .entity
+            .also { createChatRoom.invoke(it) }
+    }
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingRestController.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingRestController.kt
@@ -3,7 +3,7 @@ package com.studentcenter.weave.bootstrap.meeting.controller
 import com.studentcenter.weave.application.meeting.port.inbound.FindMyRequestMeetingByReceivingTeamIdUseCase
 import com.studentcenter.weave.application.meeting.port.inbound.GetAllOtherTeamMemberInfoUseCase
 import com.studentcenter.weave.application.meeting.port.inbound.GetMeetingAttendancesUseCase
-import com.studentcenter.weave.application.meeting.port.inbound.MeetingAttendanceCreateUseCase
+import com.studentcenter.weave.application.meeting.port.inbound.CreateMeetingAttendance
 import com.studentcenter.weave.application.meeting.port.inbound.MeetingRequestUseCase
 import com.studentcenter.weave.application.meeting.port.inbound.ScrollPendingMeetingUseCase
 import com.studentcenter.weave.application.meeting.port.inbound.ScrollPreparedMeetingUseCase
@@ -25,7 +25,7 @@ class MeetingRestController(
     private val scrollPendingMeetingUseCase: ScrollPendingMeetingUseCase,
     private val scrollPreparedMeetingUseCase: ScrollPreparedMeetingUseCase,
     private val getMeetingAttendancesUseCase: GetMeetingAttendancesUseCase,
-    private val meetingAttendanceCreateUseCase: MeetingAttendanceCreateUseCase,
+    private val createMeetingAttendance: CreateMeetingAttendance,
     private val findMyRequestMeetingByReceivingTeamIdUseCase: FindMyRequestMeetingByReceivingTeamIdUseCase,
     private val getAllOtherTeamMemberInfoUseCase: GetAllOtherTeamMemberInfoUseCase,
 ) : MeetingApi {
@@ -58,14 +58,14 @@ class MeetingRestController(
     }
 
     override fun createAttendanceForAttend(meetingId: UUID) {
-        meetingAttendanceCreateUseCase.invoke(
+        createMeetingAttendance.invoke(
             meetingId = meetingId,
             attendance = true,
         )
     }
 
     override fun createAttendanceForPass(meetingId: UUID) {
-        meetingAttendanceCreateUseCase.invoke(
+        createMeetingAttendance.invoke(
             meetingId = meetingId,
             attendance = false,
         )

--- a/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/integration/CreateMeetingAttendanceIntegrationTest.kt
+++ b/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/integration/CreateMeetingAttendanceIntegrationTest.kt
@@ -1,7 +1,7 @@
 package com.studentcenter.weave.bootstrap.integration
 
 import com.studentcenter.weave.application.common.security.context.UserSecurityContext
-import com.studentcenter.weave.application.meeting.service.application.MeetingAttendanceCreateApplicationService
+import com.studentcenter.weave.application.meeting.service.application.CreateMeetingAttendanceService
 import com.studentcenter.weave.application.meeting.service.domain.MeetingAttendanceDomainService
 import com.studentcenter.weave.application.meeting.service.domain.MeetingDomainService
 import com.studentcenter.weave.application.meetingTeam.port.outbound.MeetingTeamRepository
@@ -22,12 +22,12 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.matchers.shouldBe
 
-@DisplayName("MeetingAttendanceCreateApplicationService Integration Test")
-class MeetingAttendanceCreateApplicationServiceIntegrationTest(
+@DisplayName("CreateMeetingAttendance Integration Test")
+class CreateMeetingAttendanceIntegrationTest(
     private val meetingDomainService: MeetingDomainService,
     private val meetingAttendanceDomainService: MeetingAttendanceDomainService,
     private val meetingTeamRepository: MeetingTeamRepository,
-    private val sut: MeetingAttendanceCreateApplicationService,
+    private val sut: CreateMeetingAttendanceService,
 ) : IntegrationTestDescribeSpec({
 
     val currentUser = UserFixtureFactory.create()
@@ -185,7 +185,7 @@ class MeetingAttendanceCreateApplicationServiceIntegrationTest(
     }
 
     context("미팅 참여하는 경우, 마지막 참여라면") {
-        it("미팅이 완료 상태로 변경된다.") {
+        it("미팅이 완료 상태로 변경하고, 미팅 완료 이벤트를 발행한다") {
             // arrange
             val attendance = true
             val memberCount = 2
@@ -219,6 +219,7 @@ class MeetingAttendanceCreateApplicationServiceIntegrationTest(
 
             // assert
             meetingDomainService.getById(meeting.id).status shouldBe MeetingStatus.COMPLETED
+
         }
     }
 

--- a/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingEventHandlerTest.kt
+++ b/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingEventHandlerTest.kt
@@ -1,0 +1,39 @@
+package com.studentcenter.weave.bootstrap.meeting.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import com.studentcenter.weave.application.chat.port.inbound.CreateChatRoom
+import com.studentcenter.weave.bootstrap.integration.IntegrationTestDescribeSpec
+import com.studentcenter.weave.domain.meeting.entity.MeetingFixtureFactory
+import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
+import com.studentcenter.weave.domain.meeting.event.MeetingCompletedEvent.Companion.createCompletedEvent
+import io.kotest.core.annotation.DisplayName
+import io.mockk.every
+import io.mockk.just
+import io.mockk.runs
+import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
+
+@DisplayName("MeetingEventHandler 테스트")
+class MeetingEventHandlerTest(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+    @MockkBean
+    private val createChatRoom: CreateChatRoom,
+) : IntegrationTestDescribeSpec({
+
+    describe("미팅 완료 이벤트를 전달 받으면") {
+        it("새로운 채팅방을 생성한다") {
+            // arrange
+            val meetingFixture = MeetingFixtureFactory.create(status = MeetingStatus.COMPLETED)
+            val meetingCompletedEvent = meetingFixture.createCompletedEvent()
+
+            every { createChatRoom.invoke(meetingCompletedEvent.entity) } just runs
+
+            // act
+            applicationEventPublisher.publishEvent(meetingCompletedEvent)
+
+            // assert
+            verify { createChatRoom.invoke(meetingCompletedEvent.entity) }
+        }
+    }
+
+})

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/common/AggregateRoot.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/common/AggregateRoot.kt
@@ -1,0 +1,3 @@
+package com.studentcenter.weave.domain.common
+
+interface AggregateRoot : DomainEntity

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/common/DomainEntity.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/common/DomainEntity.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.domain.common
+
+import java.util.*
+
+interface DomainEntity {
+
+    val id: UUID
+
+}

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/common/DomainEvent.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/common/DomainEvent.kt
@@ -1,0 +1,7 @@
+package com.studentcenter.weave.domain.common
+
+interface DomainEvent<T : DomainEntity> {
+
+    val entity: T
+
+}

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/common/DomainEvent.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/common/DomainEvent.kt
@@ -1,6 +1,6 @@
 package com.studentcenter.weave.domain.common
 
-interface DomainEvent<T : DomainEntity> {
+interface DomainEvent<T : AggregateRoot> {
 
     val entity: T
 

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/entity/Meeting.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/entity/Meeting.kt
@@ -1,6 +1,6 @@
 package com.studentcenter.weave.domain.meeting.entity
 
-import com.studentcenter.weave.domain.common.DomainEntity
+import com.studentcenter.weave.domain.common.AggregateRoot
 import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
 import com.studentcenter.weave.support.common.uuid.UuidCreator
 import java.time.LocalDateTime
@@ -13,7 +13,7 @@ data class Meeting(
     val status: MeetingStatus = MeetingStatus.PENDING,
     val createdAt: LocalDateTime = LocalDateTime.now(),
     val finishedAt: LocalDateTime? = null,
-) : DomainEntity {
+) : AggregateRoot {
 
     val pendingEndAt: LocalDateTime = createdAt.plusDays(PENDING_DAYS)
 

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/entity/Meeting.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/entity/Meeting.kt
@@ -1,18 +1,20 @@
 package com.studentcenter.weave.domain.meeting.entity
 
+import com.studentcenter.weave.domain.common.DomainEntity
 import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
 import com.studentcenter.weave.support.common.uuid.UuidCreator
 import java.time.LocalDateTime
 import java.util.*
 
 data class Meeting(
-    val id: UUID = UuidCreator.create(),
+    override val id: UUID = UuidCreator.create(),
     val requestingTeamId: UUID,
     val receivingTeamId: UUID,
     val status: MeetingStatus = MeetingStatus.PENDING,
     val createdAt: LocalDateTime = LocalDateTime.now(),
     val finishedAt: LocalDateTime? = null,
-) {
+) : DomainEntity {
+
     val pendingEndAt: LocalDateTime = createdAt.plusDays(PENDING_DAYS)
 
     init {
@@ -56,6 +58,7 @@ data class Meeting(
     }
 
     companion object {
+
         const val PENDING_DAYS = 3L
 
         fun create(

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/event/MeetingCompletedEvent.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/event/MeetingCompletedEvent.kt
@@ -1,0 +1,16 @@
+package com.studentcenter.weave.domain.meeting.event
+
+import com.studentcenter.weave.domain.common.DomainEvent
+import com.studentcenter.weave.domain.meeting.entity.Meeting
+
+data class MeetingCompletedEvent(
+    override val entity: Meeting,
+) : DomainEvent<Meeting> {
+
+    companion object {
+        fun Meeting.createCompletedEvent(): MeetingCompletedEvent {
+            return MeetingCompletedEvent(this)
+        }
+    }
+
+}

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/event/MeetingCompletedEvent.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meeting/event/MeetingCompletedEvent.kt
@@ -8,9 +8,13 @@ data class MeetingCompletedEvent(
 ) : DomainEvent<Meeting> {
 
     companion object {
+
         fun Meeting.createCompletedEvent(): MeetingCompletedEvent {
+            require(isCompleted()) { "미팅이 완료되지 않았습니다." }
+
             return MeetingCompletedEvent(this)
         }
+
     }
 
 }


### PR DESCRIPTION
- 미팅 매칭시 이벤트를 발행하고, 해당 이벤트를 전달 받으면 채팅방을 생성하도록 구현했어요
- 도메인 이벤트를 구현하면서 DomainEntity 추상 클래스를 도입했는데, approve되면 다른도메인 엔티티에도 일괄적으로 적용하는 리팩토링 진행할게요

```mermaid
graph TD
    A[CreateMeetingAttendanceService] -->|"invoke(meetingId, attendance)"| B{미팅 참여 여부 확인}
    B -->|마지막 참여자| C["Meeting.complete()"]
    C --> D["MeetingDomainService.save(meeting)"]
    C --> E["MeetingCompletedEvent 생성"]
    E --> F["MeetingEventPublisher.publish(event)"]
    F --> G["ApplicationEventPublisher.publishEvent(event)"]
    G --> H["MeetingEventHandler.handleMeetingEvent(event)"]
    H --> I["CreateChatRoom.invoke(meeting)"]
    B -->|마지막 참여자 아님| J[종료]
```