### PR TITLE
[WEAV-000] 미팅매칭시 이벤트 메시지 발송 리펙터링

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/chat/port/inbound/CreateChatRoom.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/chat/port/inbound/CreateChatRoom.kt
@@ -1,9 +1,9 @@
 package com.studentcenter.weave.application.chat.port.inbound
 
-import com.studentcenter.weave.domain.meeting.entity.Meeting
+import com.studentcenter.weave.domain.meeting.event.MeetingCompletedEvent
 
 interface CreateChatRoom {
 
-    fun invoke(meeting: Meeting)
+    fun invoke(meetingCompletedEvent: MeetingCompletedEvent)
 
 }

--- a/application/src/main/kotlin/com/studentcenter/weave/application/chat/service/CreateChatRoomService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/chat/service/CreateChatRoomService.kt
@@ -3,17 +3,17 @@ package com.studentcenter.weave.application.chat.service
 import com.studentcenter.weave.application.chat.port.inbound.CreateChatRoom
 import com.studentcenter.weave.application.chat.port.outbound.ChatRoomRepository
 import com.studentcenter.weave.domain.chat.entity.ChatRoom
-import com.studentcenter.weave.domain.meeting.entity.Meeting
+import com.studentcenter.weave.domain.meeting.event.MeetingCompletedEvent
 import org.springframework.stereotype.Service
 
 @Service
-class CreateChatRoomService (
-    private val chatRoomRepository: ChatRoomRepository
-): CreateChatRoom {
+class CreateChatRoomService(
+    private val chatRoomRepository: ChatRoomRepository,
+) : CreateChatRoom {
 
-    override fun invoke(meeting: Meeting) {
+    override fun invoke(meetingCompletedEvent: MeetingCompletedEvent) {
         ChatRoom
-            .create(meeting)
+            .create(meetingCompletedEvent.entity)
             .also { chatRoomRepository.save(it) }
     }
 

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/NotifyMeetingEvent.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/inbound/NotifyMeetingEvent.kt
@@ -1,0 +1,9 @@
+package com.studentcenter.weave.application.meeting.port.inbound
+
+import com.studentcenter.weave.domain.meeting.event.MeetingCompletedEvent
+
+interface NotifyMeetingEvent {
+
+    fun notifyMeetingCompleted(meetingCompletedEvent: MeetingCompletedEvent)
+
+}

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingEventMessagePort.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/port/outbound/MeetingEventMessagePort.kt
@@ -2,7 +2,7 @@ package com.studentcenter.weave.application.meeting.port.outbound
 
 import com.studentcenter.weave.application.meeting.vo.MeetingMatchingEvent
 
-fun interface MeetingEventPort {
+fun interface MeetingEventMessagePort {
 
     fun sendMeetingIsMatchedMessage(meetingMatchingEvent: MeetingMatchingEvent)
 

--- a/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/NotifyMeetingEventService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meeting/service/application/NotifyMeetingEventService.kt
@@ -1,0 +1,50 @@
+package com.studentcenter.weave.application.meeting.service.application
+
+import com.studentcenter.weave.application.meeting.port.inbound.NotifyMeetingEvent
+import com.studentcenter.weave.application.meeting.port.outbound.MeetingEventMessagePort
+import com.studentcenter.weave.application.meeting.service.domain.MeetingDomainService
+import com.studentcenter.weave.application.meeting.vo.MeetingMatchingEvent
+import com.studentcenter.weave.application.meetingTeam.port.inbound.GetMeetingTeam
+import com.studentcenter.weave.domain.meeting.entity.Meeting
+import com.studentcenter.weave.domain.meeting.event.MeetingCompletedEvent
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamMemberSummary
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class NotifyMeetingEventService(
+    private val meetingDomainService: MeetingDomainService,
+    private val meetingEventMessagePort: MeetingEventMessagePort,
+    private val getMeetingTeam: GetMeetingTeam,
+) : NotifyMeetingEvent {
+
+    @Transactional
+    override fun notifyMeetingCompleted(meetingCompletedEvent: MeetingCompletedEvent) {
+        val meeting: Meeting = meetingCompletedEvent.entity
+        val matchedMeetingCount: Int = meetingDomainService.countByStatusIsCompleted()
+
+        val requestingMeetingTeamMemberSummary: MeetingTeamMemberSummary =
+            getMeetingTeam.getMeetingTeamMemberSummaryByMeetingTeamId(meeting.requestingTeamId)
+        val receivingMeetingTeamMemberSummary: MeetingTeamMemberSummary =
+            getMeetingTeam.getMeetingTeamMemberSummaryByMeetingTeamId(meeting.receivingTeamId)
+
+        MeetingMatchingEvent(
+            meeting = meeting,
+            memberCount = getMeetingMemberCount(meeting),
+            matchedMeetingCount = matchedMeetingCount,
+            requestingMeetingTeamMbti = requestingMeetingTeamMemberSummary.teamMbti,
+            receivingMeetingTeamMbti = receivingMeetingTeamMemberSummary.teamMbti,
+        ).also {
+            meetingEventMessagePort.sendMeetingIsMatchedMessage(it)
+        }
+    }
+
+    private fun getMeetingMemberCount(meeting: Meeting): Int {
+        val requestingTeam = getMeetingTeam.getById(meeting.requestingTeamId)
+        val receivingTeam = getMeetingTeam.getById(meeting.receivingTeamId)
+
+        return requestingTeam.memberCount + receivingTeam.memberCount
+    }
+
+
+}

--- a/application/src/test/kotlin/com/studentcenter/weave/application/chat/service/CreateChatRoomServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/chat/service/CreateChatRoomServiceTest.kt
@@ -4,7 +4,7 @@ import com.studentcenter.weave.application.chat.outbound.ChatRoomRepositorySpy
 import com.studentcenter.weave.domain.chat.entity.ChatRoom
 import com.studentcenter.weave.domain.meeting.entity.MeetingFixtureFactory
 import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
-import io.kotest.assertions.throwables.shouldThrow
+import com.studentcenter.weave.domain.meeting.event.MeetingCompletedEvent
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -26,9 +26,10 @@ class CreateChatRoomServiceTest : DescribeSpec({
             it("채팅방을 생성한다") {
                 // arrange
                 val meeting = MeetingFixtureFactory.create(status = MeetingStatus.COMPLETED)
+                val event = MeetingCompletedEvent(meeting)
 
                 // act
-                sut.invoke(meeting)
+                sut.invoke(event)
 
                 // assert
                 val savedChatRooms: List<ChatRoom> = chatRoomRepositorySpy.findAll()
@@ -38,20 +39,6 @@ class CreateChatRoomServiceTest : DescribeSpec({
                 savedChatRoom.meetingId shouldBe meeting.id
                 savedChatRoom.requestingTeamId shouldBe meeting.requestingTeamId
                 savedChatRoom.receivingTeamId shouldBe meeting.receivingTeamId
-            }
-        }
-
-        MeetingStatus.entries.filter { it != MeetingStatus.COMPLETED }.forEach { status ->
-            context("매칭되지 않은 미팅 정보가 주어졌을때 - $status") {
-                it("예외를 발생시킨다") {
-                    // arrange
-                    val meeting = MeetingFixtureFactory.create(status = status)
-
-                    // act & assert
-                    shouldThrow<IllegalArgumentException> {
-                        sut.invoke(meeting)
-                    }
-                }
             }
         }
     }

--- a/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/NotifyMeetingEventServiceTest.kt
+++ b/application/src/test/kotlin/com/studentcenter/weave/application/meeting/service/application/NotifyMeetingEventServiceTest.kt
@@ -1,0 +1,71 @@
+package com.studentcenter.weave.application.meeting.service.application
+
+import com.studentcenter.weave.application.meeting.outbound.MeetingEventMessagePortSpy
+import com.studentcenter.weave.application.meeting.outbound.MeetingRepositorySpy
+import com.studentcenter.weave.application.meeting.service.domain.impl.MeetingDomainServiceImpl
+import com.studentcenter.weave.application.meetingTeam.port.inbound.GetMeetingTeam
+import com.studentcenter.weave.domain.meeting.entity.MeetingFixtureFactory
+import com.studentcenter.weave.domain.meeting.enums.MeetingStatus
+import com.studentcenter.weave.domain.meeting.event.MeetingCompletedEvent
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamFixtureFactory
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamMemberSummaryFixtureFactory
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+@DisplayName("NotifyMeetingEventService")
+class NotifyMeetingEventServiceTest : DescribeSpec({
+
+    val meetingRepository = MeetingRepositorySpy()
+    val meetingDomainService = MeetingDomainServiceImpl(meetingRepository)
+    val meetingEventMessagePort = MeetingEventMessagePortSpy()
+    val getMeetingTeamMock = mockk<GetMeetingTeam>()
+
+    val sut = NotifyMeetingEventService(
+        meetingDomainService = meetingDomainService,
+        meetingEventMessagePort = meetingEventMessagePort,
+        getMeetingTeam = getMeetingTeamMock,
+    )
+
+    describe("notifyMeetingCompleted") {
+        it("미팅 완료 이벤트 발생시 알림 메시지를 전송한다") {
+            // arrange
+            val requestMeetingTeam = MeetingTeamFixtureFactory.create()
+            val receivingMeetingTeam = MeetingTeamFixtureFactory.create()
+
+            val requestingMeetingTeamMemberSummary = MeetingTeamMemberSummaryFixtureFactory.create(
+                meetingTeamId = requestMeetingTeam.id,
+            )
+            val receivingMeetingTeamMemberSummary = MeetingTeamMemberSummaryFixtureFactory.create(
+                meetingTeamId = receivingMeetingTeam.id,
+            )
+
+            val meeting = MeetingFixtureFactory.create(
+                requestingTeamId = requestMeetingTeam.id,
+                receivingTeamId = receivingMeetingTeam.id,
+                status = MeetingStatus.COMPLETED
+            )
+            meetingRepository.save(meeting)
+
+            val event = MeetingCompletedEvent(meeting)
+
+            every { getMeetingTeamMock.getMeetingTeamMemberSummaryByMeetingTeamId(requestMeetingTeam.id) } returns requestingMeetingTeamMemberSummary
+            every {
+                getMeetingTeamMock.getMeetingTeamMemberSummaryByMeetingTeamId(
+                    receivingMeetingTeam.id
+                )
+            } returns receivingMeetingTeamMemberSummary
+            every { getMeetingTeamMock.getById(requestMeetingTeam.id) } returns requestMeetingTeam
+            every { getMeetingTeamMock.getById(receivingMeetingTeam.id) } returns receivingMeetingTeam
+
+            // act
+            sut.notifyMeetingCompleted(event)
+
+            // assert
+            meetingEventMessagePort.count() shouldBe 1
+        }
+    }
+
+})

--- a/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingEventMessagePortSpy.kt
+++ b/application/src/testFixtures/kotlin/com/studentcenter/weave/application/meeting/outbound/MeetingEventMessagePortSpy.kt
@@ -1,0 +1,22 @@
+package com.studentcenter.weave.application.meeting.outbound
+
+import com.studentcenter.weave.application.meeting.port.outbound.MeetingEventMessagePort
+import com.studentcenter.weave.application.meeting.vo.MeetingMatchingEvent
+
+class MeetingEventMessagePortSpy: MeetingEventMessagePort {
+
+    private val meetingMatchingEvents = mutableListOf<MeetingMatchingEvent>()
+
+    override fun sendMeetingIsMatchedMessage(meetingMatchingEvent: MeetingMatchingEvent) {
+        meetingMatchingEvents.add(meetingMatchingEvent)
+    }
+
+    fun count(): Int {
+        return meetingMatchingEvents.size
+    }
+
+    fun clear() {
+        meetingMatchingEvents.clear()
+    }
+
+}

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingEventHandler.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingEventHandler.kt
@@ -1,20 +1,26 @@
 package com.studentcenter.weave.bootstrap.meeting.controller
 
 import com.studentcenter.weave.application.chat.port.inbound.CreateChatRoom
+import com.studentcenter.weave.application.meeting.port.inbound.NotifyMeetingEvent
 import com.studentcenter.weave.domain.meeting.event.MeetingCompletedEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Controller
 
 @Controller
 class MeetingEventHandler(
     private val createChatRoom: CreateChatRoom,
+    private val notifyMeetingEvent: NotifyMeetingEvent,
 ) {
 
     @EventListener
     fun handleMeetingEvent(meetingCompletedEvent: MeetingCompletedEvent) {
-        meetingCompletedEvent
-            .entity
-            .also { createChatRoom.invoke(it) }
+        CoroutineScope(Dispatchers.Default).launch {
+            launch { createChatRoom.invoke(meetingCompletedEvent.entity) }
+            launch { notifyMeetingEvent.notifyMeetingCompleted(meetingCompletedEvent) }
+        }
     }
 
 }

--- a/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingEventHandler.kt
+++ b/bootstrap/http/src/main/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingEventHandler.kt
@@ -18,7 +18,7 @@ class MeetingEventHandler(
     @EventListener
     fun handleMeetingEvent(meetingCompletedEvent: MeetingCompletedEvent) {
         CoroutineScope(Dispatchers.Default).launch {
-            launch { createChatRoom.invoke(meetingCompletedEvent.entity) }
+            launch { createChatRoom.invoke(meetingCompletedEvent) }
             launch { notifyMeetingEvent.notifyMeetingCompleted(meetingCompletedEvent) }
         }
     }

--- a/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingEventHandlerTest.kt
+++ b/bootstrap/http/src/test/kotlin/com/studentcenter/weave/bootstrap/meeting/controller/MeetingEventHandlerTest.kt
@@ -26,13 +26,13 @@ class MeetingEventHandlerTest(
             val meetingFixture = MeetingFixtureFactory.create(status = MeetingStatus.COMPLETED)
             val meetingCompletedEvent = meetingFixture.createCompletedEvent()
 
-            every { createChatRoom.invoke(meetingCompletedEvent.entity) } just runs
+            every { createChatRoom.invoke(meetingCompletedEvent) } just runs
 
             // act
             applicationEventPublisher.publishEvent(meetingCompletedEvent)
 
             // assert
-            verify { createChatRoom.invoke(meetingCompletedEvent.entity) }
+            verify { createChatRoom.invoke(meetingCompletedEvent) }
         }
     }
 

--- a/infrastructure/client/src/main/kotlin/com/studentcenter/weave/infrastructure/client/discord/meeting/adaptor/MeetingEventMessageDiscordAdaptor.kt
+++ b/infrastructure/client/src/main/kotlin/com/studentcenter/weave/infrastructure/client/discord/meeting/adaptor/MeetingEventMessageDiscordAdaptor.kt
@@ -1,19 +1,22 @@
 package com.studentcenter.weave.infrastructure.client.discord.meeting.adaptor
 
-import com.studentcenter.weave.application.meeting.port.outbound.MeetingEventPort
+import com.studentcenter.weave.application.meeting.port.outbound.MeetingEventMessagePort
 import com.studentcenter.weave.application.meeting.vo.MeetingMatchingEvent
 import com.studentcenter.weave.infrastructure.client.common.event.EventType
 import com.studentcenter.weave.infrastructure.client.common.properties.ClientProperties
 import com.studentcenter.weave.infrastructure.client.discord.common.vo.DiscordMessage
 import com.studentcenter.weave.infrastructure.client.discord.util.DiscordClient
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
 import java.net.URI
 
 @Component
-class MeetingEventDiscordAdaptor(
+class MeetingEventMessageDiscordAdaptor(
     val discordClient: DiscordClient,
     val clientProperties: ClientProperties,
-) : MeetingEventPort {
+) : MeetingEventMessagePort {
+
+    private val logger = KotlinLogging.logger {}
 
     override fun sendMeetingIsMatchedMessage(meetingMatchingEvent: MeetingMatchingEvent) {
         if (this.clientProperties.events.getValue(EventType.MEETING_MATCHING).active) {
@@ -32,7 +35,7 @@ class MeetingEventDiscordAdaptor(
                     message = DiscordMessage(message),
                 )
             }.onFailure {
-                // TODO: 로깅 시스템 도입 시 로그 추가.
+                logger.error(it) { "Failed to send discord message" }
             }
         }
     }


### PR DESCRIPTION
- 미팅 매칭 완료시 디스코드 메시지 발송 로직을 기존의 유스케이스(어플리케이션 서비스)에서 수행하던 것에서 이벤트 리스너로 옮기는 리팩토링을 진행했어요

## 주요 변경 사항

- MeetingEventHandler에서 MeetingCompletedEvent 이벤트를 받아 비동기로 NotifyMeetingEvent.notifyMeetingCompleted() 메서드를 호출하도록 하였습니다.
- NotifyMeetingEventService에서는 전달받은 MeetingCompletedEvent를 가지고 필요한 데이터를 조합한 후 MeetingEventMessagePort를 통해 메시지 발송을 위임합니다.
- 기존의 MeetingEventPort와 MeetingEventDiscordAdaptor는 각각 MeetingEventMessagePort와 MeetingEventMessageDiscordAdaptor로 이름을 변경하였습니다.

## 추가 논의사항

- 어제 구두로 논의했던 내용중에서 도메인 이벤트를 받는 리스너들은 bootstrap의 event패키지에 모아두자 라고 이야기 했던 부분이 고민이 되네요, `특정 도메인의 Primary Adatper의 역할을 한다` 라고 본다면 각 도메인들의 패키지에 위치하는게 어색한데,(다른 도메인의 inbound port를 호출할 수도 있으니), `어떤 도메인의 이벤트를 처리하느냐` 의 관점에서본다면 도메인 패키지에 위치하는것도 큰문제는 없어보이고 되려 외부에서 보기엔 더 직관적인 위치가 될것같아서요