### PR TITLE
[WEAV-000] 미팅 팀원 요약정보 생성 핫픽스

### DIFF
--- a/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/JoinMeetingTeamService.kt
+++ b/application/src/main/kotlin/com/studentcenter/weave/application/meetingTeam/service/application/JoinMeetingTeamService.kt
@@ -2,10 +2,16 @@ package com.studentcenter.weave.application.meetingTeam.service.application
 
 import com.studentcenter.weave.application.common.security.context.getCurrentUserAuthentication
 import com.studentcenter.weave.application.meetingTeam.port.inbound.JoinMeetingTeam
+import com.studentcenter.weave.application.meetingTeam.port.outbound.MeetingTeamMemberSummaryRepository
 import com.studentcenter.weave.application.meetingTeam.port.outbound.MeetingTeamRepository
 import com.studentcenter.weave.application.meetingTeam.util.MeetingTeamInvitationService
 import com.studentcenter.weave.application.user.port.inbound.GetUser
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingMember
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeam
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamMemberSummary
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamMemberSummary.Companion.createSummary
 import com.studentcenter.weave.domain.meetingTeam.exception.MeetingTeamException
+import com.studentcenter.weave.domain.user.entity.User
 import org.springframework.stereotype.Service
 import java.util.*
 
@@ -13,11 +19,12 @@ import java.util.*
 class JoinMeetingTeamService(
     private val meetingTeamRepository: MeetingTeamRepository,
     private val meetingTeamInvitationService: MeetingTeamInvitationService,
+    private val meetingTeamMemberSummaryRepository: MeetingTeamMemberSummaryRepository,
     private val getUser: GetUser,
 ) : JoinMeetingTeam {
 
     override fun invoke(invitationCode: UUID) {
-        val currentUser = getCurrentUserAuthentication().userId
+        val currentUser: User = getCurrentUserAuthentication().userId
             .let { getUser.getById(it) }
 
         val meetingTeam = meetingTeamInvitationService
@@ -25,9 +32,21 @@ class JoinMeetingTeamService(
             ?.let { meetingTeamRepository.getById(it.teamId) }
             ?: throw MeetingTeamException.InvitationCodeNotFound()
 
-        meetingTeam
+        val memberJoinedMeetingTeam: MeetingTeam = meetingTeam
             .joinMember(currentUser)
             .also { meetingTeamRepository.save(it) }
+
+        if (memberJoinedMeetingTeam.isPublished()) {
+            val summary: MeetingTeamMemberSummary =
+                memberJoinedMeetingTeam.createSummary { getUsersByMeetingMembers(it) }
+            meetingTeamMemberSummaryRepository.save(summary)
+        }
+    }
+
+    private fun getUsersByMeetingMembers(members: List<MeetingMember>): List<User> {
+        return members
+            .map { it.userId }
+            .let { getUser.getAllByIds(it) }
     }
 
 }

--- a/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
+++ b/domain/src/main/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummary.kt
@@ -25,18 +25,16 @@ data class MeetingTeamMemberSummary(
 
     companion object {
 
-        fun create(
-            meetingTeamId: UUID,
-            members: List<User>,
+        fun MeetingTeam.createSummary(
+            getUsersByMeetingMembers: (List<MeetingMember>) -> List<User>
         ): MeetingTeamMemberSummary {
-            require(members.isNotEmpty()) {
-                "팀에 속한 멤버가 존재해야 합니다."
-            }
+            val users: List<User> = getUsersByMeetingMembers(members)
+
             return MeetingTeamMemberSummary(
-                meetingTeamId = meetingTeamId,
-                teamMbti = getTeamMbti(members),
-                youngestMemberBirthYear = getYoungestMemberBirthYear(members),
-                oldestMemberBirthYear = getOldestMemberBirthYear(members)
+                meetingTeamId = this.id,
+                teamMbti = getTeamMbti(users),
+                youngestMemberBirthYear = getYoungestMemberBirthYear(users),
+                oldestMemberBirthYear = getOldestMemberBirthYear(users)
             )
         }
 

--- a/domain/src/test/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummaryTest.kt
+++ b/domain/src/test/kotlin/com/studentcenter/weave/domain/meetingTeam/entity/MeetingTeamMemberSummaryTest.kt
@@ -1,0 +1,66 @@
+package com.studentcenter.weave.domain.meetingTeam.entity
+
+
+import com.studentcenter.weave.domain.meetingTeam.entity.MeetingTeamMemberSummary.Companion.createSummary
+import com.studentcenter.weave.domain.user.entity.User
+import com.studentcenter.weave.domain.user.entity.UserFixtureFactory
+import com.studentcenter.weave.domain.user.vo.BirthYear
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+@DisplayName("MeetingTeamMemberSummary")
+class MeetingTeamMemberSummaryTest : DescribeSpec({
+
+    describe("MeetingTeamMemberSummary 생성") {
+        context("[성공] 팀에 속한 멤버가 존재할 때") {
+            it("생성에 성공한다.") {
+                // arrange
+                val users: List<User> = listOf(
+                    UserFixtureFactory.create(),
+                    UserFixtureFactory.create(),
+                    UserFixtureFactory.create(),
+                )
+                val meetingTeam = MeetingTeamFixtureFactory.create(
+                    memberCount = 3, members = users
+                )
+
+                val getUsersByMeetingMembers = { members: List<MeetingMember> -> users }
+
+                // act & assert
+                shouldNotThrowAny {
+                    meetingTeam.createSummary { getUsersByMeetingMembers(it) }
+                }
+            }
+        }
+
+        context("[성공] 가장 어린 멤버의 태어난 해와 가장 나이 많은 멤버의 태어난 해가 설정된다.") {
+            it("생성에 성공한다.") {
+                // arrange
+                val youngestMemberBirthYear = BirthYear(2000)
+                val oldestMemberBirthYear = BirthYear(1990)
+
+                val users: List<User> = listOf(
+                    UserFixtureFactory.create(birthYear = oldestMemberBirthYear),
+                    UserFixtureFactory.create(birthYear = BirthYear(1995)),
+                    UserFixtureFactory.create(birthYear = youngestMemberBirthYear),
+                )
+                val meetingTeam: MeetingTeam = MeetingTeamFixtureFactory.create(
+                    memberCount = 3, members = users
+                )
+
+                val getUsersByMeetingMembers: (List<MeetingMember>) -> List<User> =
+                    { members: List<MeetingMember> -> users }
+
+                // act
+                val summary: MeetingTeamMemberSummary =
+                    meetingTeam.createSummary { getUsersByMeetingMembers(it) }
+
+                // assert
+                summary.youngestMemberBirthYear shouldBe youngestMemberBirthYear
+                summary.oldestMemberBirthYear shouldBe oldestMemberBirthYear
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 배경
- 미팅 팀 공개상태로 변경시 팀원 요약정보가 생성되지 않는 문제 발생

## 구현 내용
- 미팅팀 공개상태 전환 여부 확인 및 요약정보 생성 및 저장 Service로직 구현